### PR TITLE
added unit and mock tests for export coverage

### DIFF
--- a/cmd/export/cluster_test.go
+++ b/cmd/export/cluster_test.go
@@ -2,14 +2,17 @@ package export
 
 import (
 	"io"
+	"sort"
 	"testing"
 
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func testLogger() logrus.FieldLogger {
@@ -27,13 +30,141 @@ func clusterRoleBindingToUnstructured(t *testing.T, crb *rbacv1.ClusterRoleBindi
 	return unstructured.Unstructured{Object: u}
 }
 
+// clusterRoleBindingUnstructuredThatFailsConversion yields an object that does not convert to rbacv1.ClusterRoleBinding.
+func clusterRoleBindingUnstructuredThatFailsConversion() unstructured.Unstructured {
+	return unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRoleBinding",
+			"metadata":   map[string]interface{}{"name": "bad"},
+			"subjects":   "not-a-list",
+		},
+	}
+}
+
+func clusterRoleToUnstructured(t *testing.T, cr *rbacv1.ClusterRole) unstructured.Unstructured {
+	t.Helper()
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	out := unstructured.Unstructured{Object: u}
+	// Typed objects often have no TypeMeta; ClusterScopedRbacHandler.accept matches on GVK.
+	out.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	return out
+}
+
+func configMapGroupResource(t *testing.T, ns, name string) *groupResource {
+	t.Helper()
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+	uobj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	return &groupResource{
+		APIGroup:        "",
+		APIVersion:      "v1",
+		APIGroupVersion: "v1",
+		APIResource:     metav1.APIResource{Kind: "ConfigMap", Name: "configmaps"},
+		objects:         &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{Object: uobj}}},
+	}
+}
+
+func serviceAccountGroupResource(t *testing.T, ns, name string) *groupResource {
+	t.Helper()
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+	uobj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(sa)
+	if err != nil {
+		t.Fatalf("ToUnstructured: %v", err)
+	}
+	return &groupResource{
+		APIGroup:        "",
+		APIVersion:      "v1",
+		APIGroupVersion: "v1",
+		APIResource:     metav1.APIResource{Kind: "ServiceAccount", Name: "serviceaccounts"},
+		objects:         &unstructured.UnstructuredList{Items: []unstructured.Unstructured{{Object: uobj}}},
+	}
+}
+
+func clusterRoleBindingGroupResource(t *testing.T, crbs ...*rbacv1.ClusterRoleBinding) *groupResource {
+	t.Helper()
+	items := make([]unstructured.Unstructured, 0, len(crbs))
+	for _, crb := range crbs {
+		items = append(items, clusterRoleBindingToUnstructured(t, crb))
+	}
+	return &groupResource{
+		APIGroup:        rbacv1.GroupName,
+		APIVersion:      rbacv1.SchemeGroupVersion.Version,
+		APIGroupVersion: rbacv1.SchemeGroupVersion.String(),
+		APIResource: metav1.APIResource{
+			Group: rbacv1.GroupName, Kind: "ClusterRoleBinding", Name: "clusterrolebindings",
+		},
+		objects: &unstructured.UnstructuredList{Items: items},
+	}
+}
+
+func clusterRoleGroupResource(t *testing.T, crs ...*rbacv1.ClusterRole) *groupResource {
+	t.Helper()
+	items := make([]unstructured.Unstructured, 0, len(crs))
+	for _, cr := range crs {
+		items = append(items, clusterRoleToUnstructured(t, cr))
+	}
+	return &groupResource{
+		APIGroup:        rbacv1.GroupName,
+		APIVersion:      rbacv1.SchemeGroupVersion.Version,
+		APIGroupVersion: rbacv1.SchemeGroupVersion.String(),
+		APIResource: metav1.APIResource{
+			Group: rbacv1.GroupName, Kind: "ClusterRole", Name: "clusterroles",
+		},
+		objects: &unstructured.UnstructuredList{Items: items},
+	}
+}
+
+func kindNames(resources []*groupResource) (kinds, names []string) {
+	for _, r := range resources {
+		kinds = append(kinds, r.APIResource.Kind)
+		switch r.APIResource.Kind {
+		case "ClusterRoleBinding", "ClusterRole", "SecurityContextConstraints":
+			for _, it := range r.objects.Items {
+				names = append(names, r.APIResource.Kind+"/"+it.GetName())
+			}
+		default:
+			for _, it := range r.objects.Items {
+				names = append(names, r.APIResource.Kind+"/"+it.GetNamespace()+"/"+it.GetName())
+			}
+		}
+	}
+	sort.Strings(kinds)
+	sort.Strings(names)
+	return kinds, names
+}
+
 func securityContextConstraintsToUnstructured(t *testing.T, scc *securityv1.SecurityContextConstraints) unstructured.Unstructured {
 	t.Helper()
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(scc)
 	if err != nil {
 		t.Fatalf("ToUnstructured: %v", err)
 	}
-	return unstructured.Unstructured{Object: u}
+	out := unstructured.Unstructured{Object: u}
+	out.SetGroupVersionKind(securityv1.SchemeGroupVersion.WithKind("SecurityContextConstraints"))
+	return out
+}
+
+func sccGroupResource(t *testing.T, sccs ...*securityv1.SecurityContextConstraints) *groupResource {
+	t.Helper()
+	items := make([]unstructured.Unstructured, 0, len(sccs))
+	for _, scc := range sccs {
+		items = append(items, securityContextConstraintsToUnstructured(t, scc))
+	}
+	return &groupResource{
+		APIGroup:        securityv1.GroupName,
+		APIVersion:      securityv1.SchemeGroupVersion.Version,
+		APIGroupVersion: securityv1.SchemeGroupVersion.String(),
+		APIResource: metav1.APIResource{
+			Group: securityv1.GroupName, Kind: "SecurityContextConstraints", Name: "securitycontextconstraints",
+		},
+		objects: &unstructured.UnstructuredList{Items: items},
+	}
 }
 
 func TestParseServiceAccountUserSubject(t *testing.T) {
@@ -82,6 +213,297 @@ func TestGroupMatchesExportedSANamespaces(t *testing.T) {
 	if groupMatchesExportedSANamespaces("system:serviceaccounts:my-ns", nil) {
 		t.Error("empty nsSet should not match")
 	}
+}
+
+func TestIsClusterScopedResource(t *testing.T) {
+	tests := []struct {
+		group, kind string
+		want        bool
+	}{
+		{rbacv1.GroupName, "ClusterRoleBinding", true},
+		{rbacv1.GroupName, "ClusterRole", true},
+		{securityv1.GroupName, "SecurityContextConstraints", true},
+		{rbacv1.GroupName, "Role", false},
+		{"wrong.group", "ClusterRole", false},
+		{"", "ClusterRole", false},
+		{rbacv1.GroupName, "UnknownKind", false},
+	}
+	for _, tt := range tests {
+		key := tt.group + "/" + tt.kind
+		t.Run(key, func(t *testing.T) {
+			if got := isClusterScopedResource(tt.group, tt.kind); got != tt.want {
+				t.Fatalf("isClusterScopedResource(%q,%q) = %v, want %v", tt.group, tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExportedSANamespaces_skipsEmptyNamespace(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	s1 := unstructured.Unstructured{}
+	s1.SetName("no-ns-sa")
+	h.serviceAccounts = []unstructured.Unstructured{s1}
+	s2 := unstructured.Unstructured{}
+	s2.SetNamespace("has-ns")
+	s2.SetName("x")
+	h.serviceAccounts = append(h.serviceAccounts, s2)
+	m := h.exportedSANamespaces()
+	if len(m) != 1 {
+		t.Fatalf("want 1 namespace (empty ns ignored), got %#v", m)
+	}
+	if _, ok := m["has-ns"]; !ok {
+		t.Fatalf("expected only has-ns, got %#v", m)
+	}
+}
+
+func TestAcceptClusterRoleBinding_malformedUnstructured(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	u := clusterRoleBindingUnstructuredThatFailsConversion()
+	if h.acceptClusterRoleBinding(u) {
+		t.Fatal("expected reject when CRB does not convert")
+	}
+}
+
+func TestAcceptClusterRoleBinding_emptySubjects(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "empty-subjects"},
+		Subjects:   nil,
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"},
+	}
+	u := clusterRoleBindingToUnstructured(t, crb)
+	if h.acceptClusterRoleBinding(u) {
+		t.Fatal("expected reject with no subjects")
+	}
+}
+
+func TestAcceptClusterRoleBinding_serviceAccountWrongNamespace(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-wrong-ns"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "other-ns", Name: "app-sa"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"},
+	}
+	u := clusterRoleBindingToUnstructured(t, crb)
+	if h.acceptClusterRoleBinding(u) {
+		t.Fatal("expected reject when ServiceAccount subject namespace does not match an exported SA")
+	}
+}
+
+func TestAcceptClusterRoleBinding_unhandledSubjectKindIgnored(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-unknown-subject"},
+		Subjects: []rbacv1.Subject{
+			{Kind: "SomeOtherKind", Name: "x"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"},
+	}
+	u := clusterRoleBindingToUnstructured(t, crb)
+	if h.acceptClusterRoleBinding(u) {
+		t.Fatal("expected reject when no subject matches ServiceAccount, Group, or User")
+	}
+}
+
+func TestAccept_rejectsUnknownGroupVersionKind(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+	u.SetName("p1")
+	if h.accept("ClusterRole", u) {
+		t.Fatal("accept should return false when object GVK is not ClusterRole or SCC")
+	}
+}
+
+func TestAcceptClusterRole_fromUnstructuredFails(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(rbacv1.SchemeGroupVersion.WithKind("ClusterRole"))
+	u.Object["metadata"] = "not-an-object"
+	if h.acceptClusterRole(u) {
+		t.Fatal("expected reject when ClusterRole does not convert")
+	}
+}
+
+func TestAcceptClusterRole_skipsMalformedFilteredCRB(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	good := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "good-crb"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "linked-role"},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingUnstructuredThatFailsConversion(),
+			clusterRoleBindingToUnstructured(t, good),
+		}},
+	}
+	cr := clusterRoleToUnstructured(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "linked-role"}})
+	if !h.acceptClusterRole(cr) {
+		t.Fatal("expected accept after skipping CRB that fails conversion")
+	}
+}
+
+func TestAcceptClusterRole_roleRefKindNotClusterRole(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "bind-role-not-cluster"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: "same-name"},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingToUnstructured(t, crb),
+		}},
+	}
+	cr := clusterRoleToUnstructured(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "same-name"}})
+	if h.acceptClusterRole(cr) {
+		t.Fatal("expected reject when CRB RoleRef.Kind is not ClusterRole")
+	}
+}
+
+func TestAcceptClusterRole_roleRefNameMismatch(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "bind"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "wanted"},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingToUnstructured(t, crb),
+		}},
+	}
+	cr := clusterRoleToUnstructured(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "other"}})
+	if h.acceptClusterRole(cr) {
+		t.Fatal("expected reject when ClusterRole name does not match RoleRef.Name")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_fromUnstructuredFails(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+	u := unstructured.Unstructured{}
+	u.SetGroupVersionKind(securityv1.SchemeGroupVersion.WithKind("SecurityContextConstraints"))
+	u.Object["metadata"] = "invalid"
+	if h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected reject when SCC does not convert")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_malformedUsersIgnoredAcceptsViaGroup(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "scc-mixed"},
+		Users:      []string{"not-a-serviceaccount-user", "system:serviceaccount:my-ns:wrong-sa"},
+		Groups:     []string{"system:serviceaccounts:my-ns"},
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted via Groups after Users entries do not match")
+	}
+}
+
+func TestFilteredResourcesOfKind_prepareWithoutClusterRoleBindingUsesNAPlaceholder(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	h.clusterResources["ClusterRole"] = clusterRoleGroupResource(t, &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-cr"},
+	})
+	_, ok := h.filteredResourcesOfKind(admittedClusterScopeResources[1])
+	if !ok {
+		t.Fatal("expected ClusterRole in clusterResources")
+	}
+	if h.filteredClusterRoleBindings == nil || h.filteredClusterRoleBindings.APIGroup != "NA" {
+		t.Fatalf("expected NA placeholder filtered CRB holder, got %#v", h.filteredClusterRoleBindings)
+	}
+	if h.filteredClusterRoleBindings.objects == nil || len(h.filteredClusterRoleBindings.objects.Items) != 0 {
+		t.Fatal("expected empty filtered CRB list when no ClusterRoleBinding was collected")
+	}
+}
+
+func TestFilterRbacResources_nonAdmittedAPIGroupPassesResourceThrough(t *testing.T) {
+	h := NewClusterScopeHandler()
+	gr := clusterRoleGroupResource(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "leaked"}})
+	gr.APIGroup = "example.com"
+	gr.APIGroupVersion = "example.com/v1"
+	out := h.filterRbacResources([]*groupResource{gr}, testLogger())
+	if len(out) != 1 || out[0].APIResource.Kind != "ClusterRole" {
+		t.Fatalf("expected cluster-shaped resource with non-admitted APIGroup to pass through unfiltered, got %#v", out)
+	}
+}
+
+func TestFilterRbacResources_onlyClusterRoleNoBindingDropped(t *testing.T) {
+	h := NewClusterScopeHandler()
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "only-cr"}}
+	out := h.filterRbacResources([]*groupResource{clusterRoleGroupResource(t, cr)}, testLogger())
+	if len(out) != 0 {
+		t.Fatalf("expected no output (CR not linked without CRB), got %d resources", len(out))
+	}
+}
+
+func TestFilterRbacResources_clusterScopedNoneAcceptedKeepsPassthroughOnly(t *testing.T) {
+	h := NewClusterScopeHandler()
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-match"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "other", Name: "sa"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"},
+	}
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "r1"}}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "my-ns", "app-sa"),
+		clusterRoleBindingGroupResource(t, crb),
+		clusterRoleGroupResource(t, cr),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	if len(out) != 1 || out[0].APIResource.Kind != "ServiceAccount" {
+		t.Fatalf("expected only ServiceAccount kept, got %d resources kinds=%v", len(out), resourceKindsList(out))
+	}
+}
+
+func resourceKindsList(resources []*groupResource) []string {
+	var ks []string
+	for _, r := range resources {
+		ks = append(ks, r.APIResource.Kind)
+	}
+	return ks
 }
 
 func TestAcceptClusterRoleBinding_Subjects(t *testing.T) {
@@ -263,6 +685,353 @@ func TestAcceptSecurityContextConstraints_GroupWrongNamespace(t *testing.T) {
 	if h.acceptSecurityContextConstraints(u) {
 		t.Fatal("expected SCC rejected when group namespace does not match exported SAs")
 	}
+}
+
+func TestAcceptSecurityContextConstraints_Users(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "scc-users"},
+		Users:      []string{"system:serviceaccount:my-ns:app-sa"},
+		Groups:     nil,
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted via Users list")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_UsersWrongServiceAccount(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	sa := unstructured.Unstructured{}
+	sa.SetName("app-sa")
+	sa.SetNamespace("my-ns")
+	h.serviceAccounts = []unstructured.Unstructured{sa}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}},
+	}
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "scc-users"},
+		Users:      []string{"system:serviceaccount:other-ns:app-sa"},
+		Groups:     nil,
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC rejected when Users entry does not match an exported SA")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_viaClusterRoleBindingRoleRefSCC(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-use-scc"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: securityv1.GroupName,
+			Kind:     "SecurityContextConstraints",
+			Name:     "custom-scc",
+		},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingToUnstructured(t, crb),
+		}},
+	}
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "custom-scc"},
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted when a filtered CRB references it by RoleRef")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_viaSystemClusterRoleName(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-scc-system-role"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "system:openshift:scc:restricted",
+		},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingToUnstructured(t, crb),
+		}},
+	}
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "restricted"},
+	}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted via system:openshift:scc:<name> ClusterRole RoleRef")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_skipsMalformedCRBThenMatches(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	good := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "good"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: securityv1.GroupName,
+			Kind:     "SecurityContextConstraints",
+			Name:     "linked-scc",
+		},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingUnstructuredThatFailsConversion(),
+			clusterRoleBindingToUnstructured(t, good),
+		}},
+	}
+	scc := &securityv1.SecurityContextConstraints{ObjectMeta: metav1.ObjectMeta{Name: "linked-scc"}}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if !h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected SCC accepted after skipping CRB that does not convert")
+	}
+}
+
+func TestAcceptSecurityContextConstraints_roleRefSCCNameMismatch(t *testing.T) {
+	h := NewClusterScopedRbacHandler(testLogger())
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: securityv1.GroupName,
+			Kind:     "SecurityContextConstraints",
+			Name:     "wanted-scc",
+		},
+	}
+	h.filteredClusterRoleBindings = &groupResource{
+		objects: &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+			clusterRoleBindingToUnstructured(t, crb),
+		}},
+	}
+	scc := &securityv1.SecurityContextConstraints{ObjectMeta: metav1.ObjectMeta{Name: "other-scc"}}
+	u := securityContextConstraintsToUnstructured(t, scc)
+	if h.acceptSecurityContextConstraints(u) {
+		t.Fatal("expected reject when CRB RoleRef name does not match SCC metadata name")
+	}
+}
+
+func TestFilterRbacResources_keepsSecurityContextConstraintsViaRoleRef(t *testing.T) {
+	h := NewClusterScopeHandler()
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-scc"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "my-ns", Name: "app-sa"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: securityv1.GroupName,
+			Kind:     "SecurityContextConstraints",
+			Name:     "export-scc",
+		},
+	}
+	scc := &securityv1.SecurityContextConstraints{ObjectMeta: metav1.ObjectMeta{Name: "export-scc"}}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "my-ns", "app-sa"),
+		clusterRoleBindingGroupResource(t, crb),
+		sccGroupResource(t, scc),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	if len(out) != 3 {
+		t.Fatalf("want SA + CRB + SCC, got %d", len(out))
+	}
+	if !containsSorted(kindNamesOnly(out), "SecurityContextConstraints/export-scc") {
+		t.Fatalf("missing SCC: %v", kindNamesOnly(out))
+	}
+}
+
+func TestFilterRbacResources_keepsSecurityContextConstraintsViaSystemClusterRole(t *testing.T) {
+	h := NewClusterScopeHandler()
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-sys"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "my-ns", Name: "app-sa"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "system:openshift:scc:custom-scc",
+		},
+	}
+	scc := &securityv1.SecurityContextConstraints{ObjectMeta: metav1.ObjectMeta{Name: "custom-scc"}}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "my-ns", "app-sa"),
+		clusterRoleBindingGroupResource(t, crb),
+		sccGroupResource(t, scc),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	if len(out) != 3 {
+		t.Fatalf("want SA + CRB + SCC, got %d", len(out))
+	}
+}
+
+func TestFilterRbacResources_keepsSecurityContextConstraintsViaUsersOnly(t *testing.T) {
+	h := NewClusterScopeHandler()
+	scc := &securityv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{Name: "scc-by-user"},
+		Users:      []string{"system:serviceaccount:my-ns:app-sa"},
+	}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "my-ns", "app-sa"),
+		sccGroupResource(t, scc),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	if len(out) != 2 {
+		t.Fatalf("want SA + SCC, got %d", len(out))
+	}
+	if !containsSorted(kindNamesOnly(out), "SecurityContextConstraints/scc-by-user") {
+		t.Fatalf("missing SCC: %v", kindNamesOnly(out))
+	}
+}
+
+func kindNamesOnly(resources []*groupResource) []string {
+	_, names := kindNames(resources)
+	return names
+}
+
+func TestFilterRbacResources_namespaceResourcesUnchanged(t *testing.T) {
+	h := NewClusterScopeHandler()
+	cm := configMapGroupResource(t, "ns1", "cm1")
+	out := h.filterRbacResources([]*groupResource{cm}, testLogger())
+	if len(out) != 1 || out[0].objects.Items[0].GetName() != "cm1" {
+		t.Fatalf("got %#v", out)
+	}
+}
+
+func TestFilterRbacResources_dropsUnmatchedClusterRBAC(t *testing.T) {
+	h := NewClusterScopeHandler()
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan-crb"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "missing-ns", Name: "sa"},
+		},
+		RoleRef: rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "any-role"},
+	}
+	cr := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "any-role"}}
+	out := h.filterRbacResources([]*groupResource{
+		clusterRoleBindingGroupResource(t, crb),
+		clusterRoleGroupResource(t, cr),
+	}, testLogger())
+	if len(out) != 0 {
+		t.Fatalf("expected no resources (no exported SAs, CRB rejected, CR not linked), got %d", len(out))
+	}
+}
+
+func TestFilterRbacResources_keepsLinkedClusterRoleBindingAndClusterRole(t *testing.T) {
+	h := NewClusterScopeHandler()
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "export-role"}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "link-crb"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.ServiceAccountKind, Namespace: "my-ns", Name: "app-sa"},
+		},
+		RoleRef: roleRef,
+	}
+	crKeep := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "export-role"}}
+	crDrop := &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "unrelated-role"}}
+	in := []*groupResource{
+		configMapGroupResource(t, "my-ns", "cm1"),
+		serviceAccountGroupResource(t, "my-ns", "app-sa"),
+		clusterRoleBindingGroupResource(t, crb),
+		clusterRoleGroupResource(t, crKeep, crDrop),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	kinds, objNames := kindNames(out)
+	wantKinds := []string{"ClusterRole", "ClusterRoleBinding", "ConfigMap", "ServiceAccount"}
+	if len(kinds) != len(wantKinds) {
+		t.Fatalf("kinds len: got %v", kinds)
+	}
+	for i := range wantKinds {
+		if kinds[i] != wantKinds[i] {
+			t.Fatalf("kinds: got %v want %v", kinds, wantKinds)
+		}
+	}
+	if !containsSorted(objNames, "ClusterRoleBinding/link-crb") {
+		t.Fatalf("missing CRB in %v", objNames)
+	}
+	if !containsSorted(objNames, "ClusterRole/export-role") {
+		t.Fatalf("missing linked ClusterRole in %v", objNames)
+	}
+	if containsSorted(objNames, "ClusterRole/unrelated-role") {
+		t.Fatalf("unrelated ClusterRole should be removed: %v", objNames)
+	}
+}
+
+func TestFilterRbacResources_acceptsClusterRoleBindingViaGroupSubject(t *testing.T) {
+	h := NewClusterScopeHandler()
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"}
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "crb-group"},
+		Subjects: []rbacv1.Subject{
+			{Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "system:serviceaccounts:ns1"},
+		},
+		RoleRef: roleRef,
+	}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "ns1", "any-sa"),
+		clusterRoleBindingGroupResource(t, crb),
+		clusterRoleGroupResource(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "r1"}}),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	if len(out) != 3 {
+		t.Fatalf("want SA + filtered CRB + filtered ClusterRole (3), got %d", len(out))
+	}
+}
+
+func TestFilterRbacResources_filtersMultipleClusterRoleBindingsInOneList(t *testing.T) {
+	h := NewClusterScopeHandler()
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "r1"}
+	crbGood := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "good"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Namespace: "ns1", Name: "sa1"}},
+		RoleRef:    roleRef,
+	}
+	crbBad := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "bad"},
+		Subjects:   []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Namespace: "other", Name: "sa1"}},
+		RoleRef:    roleRef,
+	}
+	in := []*groupResource{
+		serviceAccountGroupResource(t, "ns1", "sa1"),
+		clusterRoleBindingGroupResource(t, crbGood, crbBad),
+		clusterRoleGroupResource(t, &rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: "r1"}}),
+	}
+	out := h.filterRbacResources(in, testLogger())
+	var crbOut *groupResource
+	for _, r := range out {
+		if r.APIResource.Kind == "ClusterRoleBinding" {
+			crbOut = r
+			break
+		}
+	}
+	if crbOut == nil || len(crbOut.objects.Items) != 1 || crbOut.objects.Items[0].GetName() != "good" {
+		t.Fatalf("expected single accepted CRB, got %#v", crbOut)
+	}
+}
+
+func containsSorted(sortedNames []string, want string) bool {
+	i := sort.SearchStrings(sortedNames, want)
+	return i < len(sortedNames) && sortedNames[i] == want
 }
 
 func TestExportedSANamespaces(t *testing.T) {

--- a/cmd/export/discover_test.go
+++ b/cmd/export/discover_test.go
@@ -1,16 +1,28 @@
 package export
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	openapi_v2 "github.com/google/gnostic-models/openapiv2"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/openapi"
+	restclient "k8s.io/client-go/rest"
+	kubetesting "k8s.io/client-go/testing"
 )
 
 // ---------- getFilePath ----------
@@ -444,6 +456,321 @@ func TestWriteErrors_SkipsEmptyKind(t *testing.T) {
 	}
 }
 
+func TestPrepareFailuresDir_failsWhenPathUnderFile(t *testing.T) {
+	base := t.TempDir()
+	blocker := filepath.Join(base, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	failuresDir := filepath.Join(blocker, "failures")
+	err := prepareFailuresDir(failuresDir)
+	if err == nil {
+		t.Fatal("expected error when failuresDir is under a file (RemoveAll fails first)")
+	}
+	if !strings.Contains(err.Error(), "failures export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareFailuresDir_mkdirFailsWhenParentDirReadOnly(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root may create directories despite parent mode")
+	}
+	base := t.TempDir()
+	if err := os.Chmod(base, 0444); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(base, 0700) }()
+	failuresDir := filepath.Join(base, "failures")
+	err := prepareFailuresDir(failuresDir)
+	if err == nil {
+		t.Fatal("expected error when parent directory is not writable (RemoveAll or MkdirAll)")
+	}
+	if !strings.Contains(err.Error(), "failures export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Parent r-x (0555): RemoveAll on a missing child succeeds; MkdirAll fails with permission denied,
+// exercising the create-failures branch (not the clear-* branch).
+func TestPrepareFailuresDir_mkdirFailsWhenParentNotWritable_rwxTrick(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root may bypass directory permissions")
+	}
+	base := t.TempDir()
+	if err := os.Chmod(base, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(base, 0700) }()
+	failuresDir := filepath.Join(base, "failures")
+	err := prepareFailuresDir(failuresDir)
+	if err == nil {
+		t.Fatal("expected MkdirAll error")
+	}
+	if !strings.Contains(err.Error(), "create failures export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareClusterResourceDir_failsWhenPathUnderFile(t *testing.T) {
+	base := t.TempDir()
+	blocker := filepath.Join(base, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	clusterDir := filepath.Join(blocker, "_cluster")
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Kind: "ClusterRole"},
+			objects: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{clusterScopedObj("r")},
+			},
+		},
+	}
+	err := prepareClusterResourceDir(clusterDir, resources)
+	if err == nil {
+		t.Fatal("expected error when cluster dir is under a file")
+	}
+	if !strings.Contains(err.Error(), "cluster export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareClusterResourceDir_mkdirFailsWhenParentDirReadOnly(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root may create directories despite parent mode")
+	}
+	base := t.TempDir()
+	if err := os.Chmod(base, 0444); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(base, 0700) }()
+	clusterDir := filepath.Join(base, "_cluster")
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Kind: "ClusterRole"},
+			objects: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{clusterScopedObj("r")},
+			},
+		},
+	}
+	err := prepareClusterResourceDir(clusterDir, resources)
+	if err == nil {
+		t.Fatal("expected error when parent directory is not writable (RemoveAll or MkdirAll)")
+	}
+	if !strings.Contains(err.Error(), "cluster export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareClusterResourceDir_mkdirFailsWhenParentNotWritable_rwxTrick(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root may bypass directory permissions")
+	}
+	base := t.TempDir()
+	if err := os.Chmod(base, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(base, 0700) }()
+	clusterDir := filepath.Join(base, "_cluster")
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Kind: "ClusterRole"},
+			objects: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{clusterScopedObj("r")},
+			},
+		},
+	}
+	err := prepareClusterResourceDir(clusterDir, resources)
+	if err == nil {
+		t.Fatal("expected MkdirAll error")
+	}
+	if !strings.Contains(err.Error(), "create cluster export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareClusterResourceDir_removeAllFailsReadOnlyParent(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root can remove entries despite parent mode")
+	}
+	base := t.TempDir()
+	clusterDir := filepath.Join(base, "_cluster")
+	if err := os.MkdirAll(clusterDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Kind: "ClusterRole"},
+			objects: &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{clusterScopedObj("r")},
+			},
+		},
+	}
+	if err := os.Chmod(base, 0500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(base, 0700) }()
+
+	err := prepareClusterResourceDir(clusterDir, resources)
+	if err == nil {
+		t.Fatal("expected error when RemoveAll cannot delete under read-only parent")
+	}
+	if !strings.Contains(err.Error(), "clear cluster export directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWriteResources_createFailsWhenTargetPathIsDirectory(t *testing.T) {
+	log := testLogger()
+	tmp := t.TempDir()
+	resourceDir := filepath.Join(tmp, "out")
+	clusterDir := filepath.Join(tmp, "_cluster")
+	if err := os.MkdirAll(resourceDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(clusterDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	nsObj := namespacedObj("ns", "pod-a")
+	nsObj.SetKind("Pod")
+	nsObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+	baseName := getFilePath(nsObj)
+	if err := os.Mkdir(filepath.Join(resourceDir, baseName), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Name: "pods", Kind: "Pod"},
+			objects:     &unstructured.UnstructuredList{Items: []unstructured.Unstructured{nsObj}},
+		},
+	}
+	errs := writeResources(resources, clusterDir, resourceDir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error, got %v", errs)
+	}
+}
+
+func TestWriteResources_marshalFails(t *testing.T) {
+	log := testLogger()
+	tmp := t.TempDir()
+	resourceDir := filepath.Join(tmp, "out")
+	clusterDir := filepath.Join(tmp, "_cluster")
+	if err := os.MkdirAll(resourceDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(clusterDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	nsObj := namespacedObj("ns", "x")
+	nsObj.SetKind("Pod")
+	nsObj.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "Pod"})
+	nsObj.Object["bad"] = make(chan int)
+
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Name: "pods", Kind: "Pod"},
+			objects:     &unstructured.UnstructuredList{Items: []unstructured.Unstructured{nsObj}},
+		},
+	}
+	errs := writeResources(resources, clusterDir, resourceDir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 marshal error, got %v", errs)
+	}
+}
+
+func TestWriteResources_createFailsWhenDestinationFileNotWritable(t *testing.T) {
+	log := testLogger()
+	tmp := t.TempDir()
+	resourceDir := filepath.Join(tmp, "out")
+	clusterDir := filepath.Join(tmp, "_cluster")
+	if err := os.MkdirAll(resourceDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(clusterDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	nsObj := namespacedObj("ns", "pod-a")
+	nsObj.SetKind("Pod")
+	nsObj.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+	path := filepath.Join(resourceDir, getFilePath(nsObj))
+	if err := os.WriteFile(path, []byte("seed"), 0400); err != nil {
+		t.Fatal(err)
+	}
+
+	resources := []*groupResource{
+		{
+			APIResource: metav1.APIResource{Name: "pods", Kind: "Pod"},
+			objects:     &unstructured.UnstructuredList{Items: []unstructured.Unstructured{nsObj}},
+		},
+	}
+	errs := writeResources(resources, clusterDir, resourceDir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error opening/truncating read-only destination file, got %v", errs)
+	}
+}
+
+func TestWriteErrors_createFailsWhenFailuresDirParentIsFile(t *testing.T) {
+	log := testLogger()
+	base := t.TempDir()
+	blocker := filepath.Join(base, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	failuresDir := filepath.Join(blocker, "failures")
+
+	listErrs := []*groupResourceError{
+		{APIResource: metav1.APIResource{Name: "widgets", Kind: "Widget"}, Error: errors.New("list failed")},
+	}
+	errs := writeErrors(listErrs, failuresDir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error, got %v", errs)
+	}
+}
+
+func TestWriteErrors_targetPathIsDirectory(t *testing.T) {
+	log := testLogger()
+	dir := t.TempDir()
+	listErrs := []*groupResourceError{
+		{APIResource: metav1.APIResource{Name: "widgets", Kind: "Widget"}, Error: errors.New("list failed")},
+	}
+	target := filepath.Join(dir, "widgets.yaml")
+	if err := os.Mkdir(target, 0700); err != nil {
+		t.Fatal(err)
+	}
+	errs := writeErrors(listErrs, dir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 error when error file path is a directory, got %v", errs)
+	}
+}
+
+// jsonMarshalFailError makes json.Marshal (used by sigs.k8s.io/yaml.Marshal) fail for writeErrors.
+type jsonMarshalFailError struct{}
+
+func (jsonMarshalFailError) Error() string { return "boom" }
+
+func (jsonMarshalFailError) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("marshal failed")
+}
+
+func TestWriteErrors_jsonMarshalFails(t *testing.T) {
+	log := testLogger()
+	dir := t.TempDir()
+	listErrs := []*groupResourceError{
+		{
+			APIResource: metav1.APIResource{Name: "widgets", Kind: "Widget"},
+			Error:       jsonMarshalFailError{},
+		},
+	}
+	errs := writeErrors(listErrs, dir, log)
+	if len(errs) != 1 {
+		t.Fatalf("want 1 yaml/json marshal error, got %v", errs)
+	}
+}
+
 // ---------- resourceToExtract ----------
 
 func TestResourceToExtract_SkipsEvents(t *testing.T) {
@@ -521,6 +848,456 @@ func TestResourceToExtract_SkipsEmptyAPIResources(t *testing.T) {
 	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
 	if len(resources) != 0 || len(errs) != 0 {
 		t.Fatal("empty APIResources list should produce no resources or errors")
+	}
+}
+
+// ---------- test discovery mock (implements discovery.DiscoveryInterface) ----------
+
+type testDiscovery struct {
+	serverPreferredResources []*metav1.APIResourceList
+	serverPreferredErr       error
+}
+
+func (d *testDiscovery) RESTClient() restclient.Interface { return nil }
+
+func (d *testDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return d.serverPreferredResources, d.serverPreferredErr
+}
+
+func (d *testDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) ServerVersion() (*version.Info, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *testDiscovery) OpenAPIV3() openapi.Client { return nil }
+
+func (d *testDiscovery) WithLegacy() discovery.DiscoveryInterface { return d }
+
+// ---------- discoverPreferredResources ----------
+
+func stdVerbs() metav1.Verbs {
+	return metav1.Verbs{"list", "create", "get", "delete"}
+}
+
+func TestDiscoverPreferredResources_filtersVerbs(t *testing.T) {
+	td := &testDiscovery{
+		serverPreferredResources: []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+					{Name: "secrets", Kind: "Secret", Namespaced: true, Verbs: metav1.Verbs{"list"}},
+				},
+			},
+		},
+	}
+	out, err := discoverPreferredResources(td, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || len(out[0].APIResources) != 1 || out[0].APIResources[0].Name != "configmaps" {
+		t.Fatalf("got %#v", out)
+	}
+}
+
+func TestDiscoverPreferredResources_groupDiscoveryFailed_partialLists(t *testing.T) {
+	partial := &discovery.ErrGroupDiscoveryFailed{
+		Groups: map[schema.GroupVersion]error{
+			{Group: "widgets.example.com", Version: "v1"}: errors.New("discovery failed"),
+		},
+	}
+	td := &testDiscovery{
+		serverPreferredErr: partial,
+		serverPreferredResources: []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: stdVerbs()},
+				},
+			},
+		},
+	}
+	out, err := discoverPreferredResources(td, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || len(out[0].APIResources) != 1 {
+		t.Fatalf("expected filtered list, got %#v", out)
+	}
+}
+
+func TestDiscoverPreferredResources_groupDiscoveryFailed_noLists(t *testing.T) {
+	partial := &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{{Group: "x", Version: "v1"}: errors.New("fail")}}
+	td := &testDiscovery{serverPreferredErr: partial, serverPreferredResources: nil}
+	_, err := discoverPreferredResources(td, testLogger())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !discovery.IsGroupDiscoveryFailedError(err) {
+		t.Fatalf("want ErrGroupDiscoveryFailed, got %v", err)
+	}
+}
+
+func TestDiscoverPreferredResources_nonDiscoveryError(t *testing.T) {
+	td := &testDiscovery{
+		serverPreferredErr: fmt.Errorf("network error"),
+		serverPreferredResources: []*metav1.APIResourceList{
+			{GroupVersion: "v1", APIResources: []metav1.APIResource{{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: stdVerbs()}}},
+		},
+	}
+	_, err := discoverPreferredResources(td, testLogger())
+	if err == nil || err.Error() != "network error" {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestDiscoverPreferredResources_partialErrorAllResourcesFilteredOut(t *testing.T) {
+	partial := &discovery.ErrGroupDiscoveryFailed{Groups: map[schema.GroupVersion]error{{Group: "x", Version: "v1"}: errors.New("fail")}}
+	td := &testDiscovery{
+		serverPreferredErr: partial,
+		serverPreferredResources: []*metav1.APIResourceList{
+			{
+				GroupVersion: "v1",
+				APIResources: []metav1.APIResource{
+					{Name: "secrets", Kind: "Secret", Namespaced: true, Verbs: metav1.Verbs{"list"}},
+				},
+			},
+		},
+	}
+	_, err := discoverPreferredResources(td, testLogger())
+	if err == nil {
+		t.Fatal("expected error when partial discovery and no resources pass verb filter")
+	}
+}
+
+// ---------- getObjects ----------
+
+func TestGetObjects_configMaps(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cm1"},
+		Data:       map[string]string{"k": "v"},
+	}
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme, cm)
+	g := &groupResource{
+		APIGroup:        "",
+		APIVersion:      "v1",
+		APIGroupVersion: "v1",
+		APIResource:     metav1.APIResource{Name: "configmaps", Kind: "ConfigMap", Namespaced: true},
+	}
+	list, err := getObjects(g, "default", "", client, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 || list.Items[0].GetName() != "cm1" {
+		t.Fatalf("got %#v", list.Items)
+	}
+}
+
+func TestGetObjects_imageStreamTagsUsesGetPerItem(t *testing.T) {
+	ist := &unstructured.Unstructured{}
+	ist.SetAPIVersion("image.openshift.io/v1")
+	ist.SetKind("ImageStreamTag")
+	ist.SetNamespace("openshift")
+	ist.SetName("ruby:latest")
+	if err := unstructured.SetNestedField(ist.Object, map[string]interface{}{"tag": map[string]interface{}{}}, "spec"); err != nil {
+		t.Fatal(err)
+	}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), ist)
+	g := &groupResource{
+		APIGroup:        "image.openshift.io",
+		APIVersion:      "v1",
+		APIGroupVersion: "image.openshift.io/v1",
+		APIResource:     metav1.APIResource{Name: "imagestreamtags", Kind: "ImageStreamTag", Namespaced: true},
+	}
+	list, err := getObjects(g, "openshift", "", client, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 || list.Items[0].GetName() != "ruby:latest" {
+		t.Fatalf("got %#v", list.Items)
+	}
+}
+
+func TestGetObjects_imagetagResourceName(t *testing.T) {
+	it := &unstructured.Unstructured{}
+	it.SetAPIVersion("example.com/v1")
+	it.SetKind("ImageTag")
+	it.SetNamespace("ns1")
+	it.SetName("img:1")
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), it)
+	g := &groupResource{
+		APIGroup:        "example.com",
+		APIVersion:      "v1",
+		APIGroupVersion: "example.com/v1",
+		APIResource:     metav1.APIResource{Name: "imagetags", Kind: "ImageTag", Namespaced: true},
+	}
+	list, err := getObjects(g, "ns1", "", client, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("got %d items", len(list.Items))
+	}
+}
+
+func TestGetObjects_passesLabelSelectorToList(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cm1", Labels: map[string]string{"app": "test"}},
+		Data:       map[string]string{"k": "v"},
+	}
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme, cm)
+	var sawLabel string
+	client.PrependReactor("list", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		la, ok := action.(kubetesting.ListActionImpl)
+		if !ok {
+			t.Fatalf("expected ListActionImpl, got %T", action)
+		}
+		sawLabel = la.GetListOptions().LabelSelector
+		return false, nil, nil
+	})
+	g := &groupResource{
+		APIGroup:        "",
+		APIVersion:      "v1",
+		APIGroupVersion: "v1",
+		APIResource:     metav1.APIResource{Name: "configmaps", Kind: "ConfigMap", Namespaced: true},
+	}
+	list, err := getObjects(g, "default", "app=test", client, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sawLabel != "app=test" {
+		t.Fatalf("LabelSelector = %q, want app=test", sawLabel)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("got %d items", len(list.Items))
+	}
+}
+
+func TestGetObjects_imageStreamTags_getFailure(t *testing.T) {
+	ist := &unstructured.Unstructured{}
+	ist.SetAPIVersion("image.openshift.io/v1")
+	ist.SetKind("ImageStreamTag")
+	ist.SetNamespace("openshift")
+	ist.SetName("ruby:latest")
+	if err := unstructured.SetNestedField(ist.Object, map[string]interface{}{"tag": map[string]interface{}{}}, "spec"); err != nil {
+		t.Fatal(err)
+	}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), ist)
+	client.PrependReactor("get", "imagestreamtags", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.New("get failed")
+	})
+	g := &groupResource{
+		APIGroup:        "image.openshift.io",
+		APIVersion:      "v1",
+		APIGroupVersion: "image.openshift.io/v1",
+		APIResource:     metav1.APIResource{Name: "imagestreamtags", Kind: "ImageStreamTag", Namespaced: true},
+	}
+	_, err := getObjects(g, "openshift", "", client, testLogger())
+	if err == nil || !strings.Contains(err.Error(), "unable to process the list") {
+		t.Fatalf("got err=%v", err)
+	}
+}
+
+func TestIterateItemsInList_rejectsNonUnstructured(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Name = "p1"
+	list := &corev1.PodList{Items: []corev1.Pod{*pod}}
+	g := &groupResource{APIGroup: "", APIResource: metav1.APIResource{Kind: "Pod"}}
+	_, err := iterateItemsInList(list, g, testLogger())
+	if err == nil || !strings.Contains(err.Error(), "unable to process the list") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestIterateItemsByGet_rejectsNonUnstructured(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Name = "p1"
+	list := &corev1.PodList{Items: []corev1.Pod{*pod}}
+	g := &groupResource{APIGroup: "", APIResource: metav1.APIResource{Kind: "Pod"}}
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	c := client.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"})
+	_, err := iterateItemsByGet(c, g, list, "default", testLogger())
+	if err == nil || !strings.Contains(err.Error(), "unable to process the list") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+// ---------- resourceToExtract integration ----------
+
+func TestResourceToExtract_loadsConfigMaps(t *testing.T) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cm1"},
+		Data:       map[string]string{"k": "v"},
+	}
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme, cm)
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(resources) != 1 || resources[0].APIResource.Name != "configmaps" || len(resources[0].objects.Items) != 1 {
+		t.Fatalf("got %d resources", len(resources))
+	}
+}
+
+func TestResourceToExtract_loadsClusterRoles(t *testing.T) {
+	cr := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "export-test-role"},
+		Rules:      []rbacv1.PolicyRule{{Verbs: []string{"get"}, APIGroups: []string{""}, Resources: []string{"pods"}}},
+	}
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme, cr)
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "clusterroles", Kind: "ClusterRole", Namespaced: false, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(errs) != 0 {
+		t.Fatalf("unexpected errs: %v", errs)
+	}
+	if len(resources) != 1 || resources[0].objects.Items[0].GetName() != "export-test-role" {
+		t.Fatalf("got %#v", resources)
+	}
+}
+
+func TestResourceToExtract_listForbidden(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	client.PrependReactor("list", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("no"))
+	})
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 {
+		t.Fatalf("expected no resources, got %d", len(resources))
+	}
+	if len(errs) != 1 || !apierrors.IsForbidden(errs[0].Error) {
+		t.Fatalf("got errs %#v", errs)
+	}
+}
+
+func TestResourceToExtract_listNotFound(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	client.PrependReactor("list", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, "x")
+	})
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 || len(errs) != 1 || !apierrors.IsNotFound(errs[0].Error) {
+		t.Fatalf("resources=%d errs=%v", len(resources), errs)
+	}
+}
+
+func TestResourceToExtract_listMethodNotSupported(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	client.PrependReactor("list", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, apierrors.NewMethodNotSupported(schema.GroupResource{Resource: "configmaps"}, "list")
+	})
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 || len(errs) != 1 || !apierrors.IsMethodNotSupported(errs[0].Error) {
+		t.Fatalf("resources=%d errs=%v", len(resources), errs)
+	}
+}
+
+func TestResourceToExtract_listGenericError(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	client.PrependReactor("list", "configmaps", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, fmt.Errorf("upstream timeout")
+	})
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 || len(errs) != 1 || errs[0].Error.Error() != "upstream timeout" {
+		t.Fatalf("resources=%d errs=%v", len(resources), errs)
+	}
+}
+
+func TestResourceToExtract_zeroObjectsNotAdded(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	lists := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "configmaps", Kind: "ConfigMap", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 || len(errs) != 0 {
+		t.Fatalf("empty list should skip resource (no error), got resources=%d errs=%v", len(resources), errs)
+	}
+}
+
+func TestResourceToExtract_skipsUnparseableGroupVersion(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(clientgoscheme.Scheme)
+	lists := []*metav1.APIResourceList{
+		{
+			// More than one "/" makes schema.ParseGroupVersion fail (no "/" => treated as version-only).
+			GroupVersion: "example.com/v1/extra",
+			APIResources: []metav1.APIResource{
+				{Name: "widgets", Kind: "Widget", Namespaced: true, Verbs: stdVerbs()},
+			},
+		},
+	}
+	resources, errs := resourceToExtract("default", "", client, lists, testLogger())
+	if len(resources) != 0 || len(errs) != 0 {
+		t.Fatalf("got resources %d errs %d", len(resources), len(errs))
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds unit and integration tests under `cmd/export` for discovery, cluster-scoped RBAC/SCC filtering, and export I/O. Improves coverage and regression safety.

## Changes

### `discover_test.go`
- `testDiscovery` mock (`discovery.DiscoveryInterface`) for `discoverPreferredResources` (verbs, partial discovery, errors, post-filter empty lists).
- `getObjects` / `resourceToExtract` (ConfigMaps, ClusterRoles, imagestreamtags/imagetags, Forbidden/NotFound, bad `GroupVersion`, Events, non-admitted cluster kinds, empty verbs/API lists).
- `prepareClusterResourceDir`, `prepareFailuresDir`, `writeResources`, `writeErrors` — happy paths and failure cases (bad paths, permissions, marshal/create errors).
- `resourceToExtract`: `MethodNotSupported`, generic list error, empty list (skip, no error).
- `getObjects`: label selector propagation; imagestreamtags when `Get` fails after `List`.
- `iterateItemsInList` / `iterateItemsByGet`: non-`*unstructured.Unstructured` list items.
- GVK fixes on unstructured test objects where handlers branch on `GroupVersionKind`.

### `cluster_test.go`
- `filterRbacResources` integration (SA + CRB + ClusterRole, group subjects, multiple CRBs, drop unmatched cluster RBAC, wrong `APIGroup` pass-through).
- `clusterRoleToUnstructured` sets GVK for `acceptClusterRole`.
- SCC: users, CRB `RoleRef` to SCC / `system:openshift:scc:<name>`, malformed filtered CRB, name mismatch; `filterRbacResources` + SCC.
- Broader `cluster.go` edge coverage: `isClusterScopedResource`, `exportedSANamespaces`, CRB/CR/SCC conversion and subject branches, NA CRB placeholder, etc.
- `clusterRoleBindingUnstructuredThatFailsConversion` for real `FromUnstructured` failures.

## How to test

```bash
go test ./cmd/export/... -count=1
go test ./cmd/export/... -count=1 -coverprofile=coverage.out
go tool cover -func=coverage.out

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for cluster resource export functionality, including validation of role-based access control (RBAC) filtering, error handling scenarios, and resource discovery behavior.
  * Added comprehensive test cases for edge cases and error paths to improve reliability of the export feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->