### PR TITLE
:test_tube: Add unit tests for transfer-pvc Progress and dataSize types & fixed typo

### DIFF
--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -408,7 +408,7 @@ func parseRsyncLogs(rawLogs string) (p *Progress, unprocessedData string) {
 	finalFileCountRegex := regexp.MustCompile(`Number of regular files transferred: (.*)`)
 	unprocessedLines := regexp.MustCompile(`.*?\n(.*)$`)
 	// retries
-	retryRegex := regexp.MustCompile(`Syncronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
+	retryRegex := regexp.MustCompile(`Synchronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
 
 	inProgressLines := fileProgressRegex.FindAllStringSubmatch(rawLogs, -1)
 	for _, matched := range inProgressLines {

--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -413,7 +413,7 @@ func parseRsyncLogs(rawLogs string) (p *Progress, unprocessedData string) {
 	finalFileCountRegex := regexp.MustCompile(`Number of regular files transferred: (.*)`)
 	unprocessedLines := regexp.MustCompile(`.*?\n(.*)$`)
 	// retries
-	retryRegex := regexp.MustCompile(`Syncronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
+	retryRegex := regexp.MustCompile(`Synchronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
 
 	inProgressLines := fileProgressRegex.FindAllStringSubmatch(rawLogs, -1)
 	for _, matched := range inProgressLines {

--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -423,7 +423,7 @@ func parseRsyncLogs(rawLogs string) (p *Progress, unprocessedData string) {
 	finalFileCountRegex := regexp.MustCompile(`Number of regular files transferred: (.*)`)
 	unprocessedLines := regexp.MustCompile(`.*?\n(.*)$`)
 	// retries
-	retryRegex := regexp.MustCompile(`Syncronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
+	retryRegex := regexp.MustCompile(`Synchronization failed. Retrying in \d+ seconds. Retry (\d+)/.*`)
 
 	inProgressLines := fileProgressRegex.FindAllStringSubmatch(rawLogs, -1)
 	for _, matched := range inProgressLines {

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -1,10 +1,22 @@
 package transfer_pvc
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
+	"os"
+	"strings"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
+// resetGlobals resets global variables between tests for isolation
+func resetGlobals() {
+	pastAttempts = Progress{}
+	failedFiles = nil
+}
 func intEqual(a, b *int64) (string, string, bool) {
 	if a != nil && b != nil && *a == *b {
 		return fmt.Sprintf("%d", a), fmt.Sprintf("%d", b), true
@@ -19,11 +31,12 @@ func intEqual(a, b *int64) (string, string, bool) {
 	return as, bs, a == b
 }
 
-func dataEqual(a, b *dataSize) (string, string, bool) {
+func dataEqual(a, b *dataSize, tolerance float64) (string, string, bool) {
 	if a != nil && b != nil {
-		if (a.val == b.val) && (a.unit == b.unit) {
+		if math.Abs(a.val-b.val) <= tolerance && a.unit == b.unit {
 			return a.String(), b.String(), true
 		}
+
 		return a.String(), b.String(), false
 	}
 	as, bs := "nil", "nil"
@@ -134,7 +147,7 @@ File list transfer time: 0.000 seconds
 Total bytes sent: 8.67G
 2022/07/14 18:09:11 [549] Total bytes received: 12.79M
 Total bytes received: 12.79M
-			
+
 2022/07/14 18:09:11 [549] sent 8.67G bytes  received 12.79M bytes  88.19M bytes/sec
 sent 8.67G bytes  received 12.79M bytes  88.19M bytes/sec
 2022/07/14 18:09:11 [549] total size is 8.67G  speedup is 1.00
@@ -160,10 +173,10 @@ total size is 8.67G  speedup is 1.00`,
 			if a, b, e := intEqual(got.TransferPercentage, tt.want.TransferPercentage); !e {
 				t.Errorf("parseRsyncLogs() percentage = %v, want %v", a, b)
 			}
-			if a, b, e := dataEqual(got.TransferredData, tt.want.TransferredData); !e {
+			if a, b, e := dataEqual(got.TransferredData, tt.want.TransferredData, 0.0); !e {
 				t.Errorf("parseRsyncLogs() dataTransferred = %v, want %v", a, b)
 			}
-			if a, b, e := dataEqual(got.TransferRate, tt.want.TransferRate); !e {
+			if a, b, e := dataEqual(got.TransferRate, tt.want.TransferRate, 0.0); !e {
 				t.Errorf("parseRsyncLogs() speed = %v, want %v", a, b)
 			}
 			if got.TransferredFiles != tt.want.TransferredFiles {
@@ -174,6 +187,758 @@ total size is 8.67G  speedup is 1.00`,
 			}
 			if unprocessed != tt.wantUnProcessed {
 				t.Errorf("parseRsyncLogs() unprocessed = %v, want %v", unprocessed, tt.wantUnProcessed)
+			}
+		})
+	}
+}
+func TestNewProgress(t *testing.T) {
+	name := types.NamespacedName{Namespace: "test-ns", Name: "test-pvc"}
+	p := NewProgress(name)
+
+	if p.PVC != name {
+		t.Errorf("NewProgress() PVC = %v, want %v", p.PVC, name)
+	}
+	if p.FailedFiles == nil || len(p.FailedFiles) != 0 {
+		t.Errorf("NewProgress() FailedFiles should be empty slice")
+	}
+	if p.Errors == nil || len(p.Errors) != 0 {
+		t.Errorf("NewProgress() Errors should be empty slice")
+	}
+	if p.startedAt.IsZero() {
+		t.Errorf("NewProgress() startedAt should not be zero")
+	}
+}
+
+func TestProgressStatus_ExitCodeZero(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(0)
+	p := &Progress{
+		ExitCode: &exitCode,
+	}
+	got := p.Status()
+	if got != succeeded {
+		t.Errorf("Progress.Status() = %v, want %v", got, succeeded)
+	}
+	if p.TransferPercentage == nil || *p.TransferPercentage != 100 {
+		t.Errorf("Progress.TransferPercentage = %v, want 100", p.TransferPercentage)
+	}
+}
+
+func TestProgressStatus_ExitCodeNonZeroNoData(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 0,
+		TransferredData:  &dataSize{val: 0, unit: "bytes"},
+		TotalFiles:       nil,
+	}
+	got := p.Status()
+	if got != failed {
+		t.Errorf("Progress.Status() = %v, want %v", got, failed)
+	}
+}
+
+func TestProgressStatus_ExitCodeNonZeroWithData(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+	}
+	got := p.Status()
+	if got != partiallyFailed {
+		t.Errorf("Progress.Status() = %v, want %v", got, partiallyFailed)
+	}
+}
+
+func TestProgressStatus_NilExitCodeNilPercentage(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: nil,
+	}
+	got := p.Status()
+	if got != preparing {
+		t.Errorf("Progress.Status() = %v, want %v", got, preparing)
+	}
+}
+
+func TestProgressStatus_PercentageGreaterThanOrEqual100(t *testing.T) {
+	resetGlobals()
+	pct := int64(100)
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: &pct,
+	}
+	got := p.Status()
+	if got != finishingUp {
+		t.Errorf("Progress.Status() = %v, want %v", got, finishingUp)
+	}
+}
+
+func TestProgressStatus_PercentageLessThan100(t *testing.T) {
+	resetGlobals()
+	pct := int64(50)
+	p := &Progress{
+		ExitCode:           nil,
+		TransferPercentage: &pct,
+	}
+	got := p.Status()
+	if got != transferInProgress {
+		t.Errorf("Progress.Status() = %v, want %v", got, transferInProgress)
+	}
+}
+
+func TestProgressMerge_BasicFields(t *testing.T) {
+	resetGlobals()
+	totalFiles := int64(150)
+	p := &Progress{
+		TransferredFiles: 10,
+		TotalFiles:       nil,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	in := &Progress{
+		TransferredFiles: 20,
+		TotalFiles:       &totalFiles,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	p.Merge(in)
+	if p.TransferredFiles != 30 {
+		t.Errorf("Merge() TransferredFiles = %v, want 30", p.TransferredFiles)
+	}
+	if p.TotalFiles == nil || *p.TotalFiles != 150 {
+		t.Errorf("Merge() TotalFiles = %v, want 150", p.TotalFiles)
+	}
+}
+
+func TestProgressMerge_PercentageAggregation(t *testing.T) {
+	resetGlobals()
+	pct1 := int64(50)
+	pct2 := int64(40)
+	p := &Progress{
+		TransferPercentage: &pct1,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &pct2,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
+	}
+}
+
+func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
+	resetGlobals()
+	inPct := int64(40)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 40")
+		return
+	}
+	if *p.TransferPercentage != 40 {
+		t.Errorf("Merge() TransferPercentage = %d, want 40", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageAccumulationWithPastAttempts(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(30)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (pastAttempts 30 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageCapAt100(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(80)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(75)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 75")
+		return
+	}
+	// pastAttempts(80) + in(30) = 110, which exceeds 100
+	// so p.TransferPercentage should remain at original value (75)
+	if *p.TransferPercentage != 75 {
+		t.Errorf("Merge() TransferPercentage = %d, want 75 (should not update when total > 100)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageOnlyUpdateIfHigher(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(40)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(40)
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 60")
+		return
+	}
+	// pastAttempts(40) + in(20) = 60, which is higher than p(40)
+	if *p.TransferPercentage != 60 {
+		t.Errorf("Merge() TransferPercentage = %d, want 60 (pastAttempts 40 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageDontUpdateIfLower(t *testing.T) {
+	resetGlobals()
+	pPct := int64(50)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	// in(30) is lower than p(50), so p should stay at 50
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (should not update when incoming is lower)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageResetWithRetries(t *testing.T) {
+	resetGlobals()
+	pPct := int64(60)
+	inPct := int64(10)
+	retryCount := 1
+	p := &Progress{
+		TransferPercentage: &pPct,
+		TransferredFiles:   100,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		retries:            &retryCount,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	// When in.retries is set, pastAttempts should be updated with p's state
+	if pastAttempts.TransferPercentage == nil {
+		t.Errorf("pastAttempts.TransferPercentage = nil after retry, want non-nil")
+		return
+	}
+	if *pastAttempts.TransferPercentage != 60 {
+		t.Errorf("pastAttempts.TransferPercentage = %d, want 60", *pastAttempts.TransferPercentage)
+	}
+	if pastAttempts.TransferredFiles != 100 {
+		t.Errorf("pastAttempts.TransferredFiles = %d, want 100", pastAttempts.TransferredFiles)
+	}
+	if p.retries == nil || *p.retries != 1 {
+		t.Errorf("p.retries should be 1 after merge")
+	}
+}
+
+// TestProgressMerge_DataSizeAggregation tests that Merge aggregates transferred data
+// when using pastAttempts (retry scenario).
+func TestProgressMerge_DataSizeAggregation(t *testing.T) {
+	resetGlobals()
+	// First, set up pastAttempts to simulate a retry scenario
+	pastAttempts = Progress{
+		TransferredData: &dataSize{val: 100.0, unit: "M"},
+	}
+	p := &Progress{
+		TransferredData: nil,
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	in := &Progress{
+		TransferredData: &dataSize{val: 50.0, unit: "M"},
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	p.Merge(in)
+	if p.TransferredData == nil {
+		t.Errorf("Merge() TransferredData = nil, want non-nil")
+		return
+	}
+	// pastAttempts(100M) + in(50M) = 150M, which should update p.TransferredData
+	if p.TransferredData.val != 150.0 {
+		t.Errorf("Merge() TransferredData.val = %v, want 150.0", p.TransferredData.val)
+	}
+}
+
+func TestProgressMerge_ErrorAndFailedFileAppending(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		Errors:      []string{"error1"},
+		FailedFiles: []FailedFile{{Name: "file1", Err: "err1"}},
+	}
+	in := &Progress{
+		Errors:      []string{"error2", "error3"},
+		FailedFiles: []FailedFile{{Name: "file2", Err: "err2"}, {Name: "file3", Err: "err3"}},
+	}
+	p.Merge(in)
+	if len(p.Errors) != 3 {
+		t.Errorf("Merge() len(Errors) = %v, want 3", len(p.Errors))
+	}
+	if len(p.FailedFiles) != 3 {
+		t.Errorf("Merge() len(FailedFiles) = %v, want 3", len(p.FailedFiles))
+	}
+}
+
+func TestProgressAsString_BasicFormat(t *testing.T) {
+	resetGlobals()
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredData:    &dataSize{val: 100.0, unit: "M"},
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Status:") {
+		t.Errorf("AsString() missing 'Status:'")
+	}
+	if !strings.Contains(out, "Progress:") {
+		t.Errorf("AsString() missing 'Progress:'")
+	}
+	if !strings.Contains(out, "Percentage:") {
+		t.Errorf("AsString() missing 'Percentage:'")
+	}
+}
+
+func TestProgressAsString_WithAllFields(t *testing.T) {
+	resetGlobals()
+	pct := int64(100)
+	exitCode := int32(0)
+	totalFiles := int64(49961)
+	retries := 2
+	p := &Progress{
+		ExitCode:           &exitCode,
+		TransferPercentage: &pct,
+		TransferRate:       &dataSize{val: 88.19, unit: "MB/s"},
+		TransferredData:    &dataSize{val: 8.67, unit: "G"},
+		TotalFiles:         &totalFiles,
+		TransferredFiles:   49948,
+		retries:            &retries,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Retries:") {
+		t.Errorf("AsString() missing 'Retries:'")
+	}
+	if !strings.Contains(out, "88.19 MB/s") {
+		t.Errorf("AsString() missing '88.19 MB/s'")
+	}
+	if !strings.Contains(out, "8.67 G") {
+		t.Errorf("AsString() missing '8.67 G'")
+	}
+}
+
+func TestProgressAsString_WithNilFields(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferPercentage: nil,
+		TransferRate:       nil,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "<unavailable>") {
+		t.Errorf("AsString() missing '<unavailable>'")
+	}
+}
+
+func TestProgressAsString_WhenCompleted(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(0)
+	totalFiles := int64(100)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 100,
+		TotalFiles:       &totalFiles,
+		startedAt:        time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Files:") {
+		t.Errorf("AsString() missing 'Files:'")
+	}
+	if !strings.Contains(out, "Sent:") {
+		t.Errorf("AsString() missing 'Sent:'")
+	}
+	if !strings.Contains(out, "Total:") {
+		t.Errorf("AsString() missing 'Total:'")
+	}
+}
+
+// TestProgressAsString_WithErrors tests that AsString includes error output when
+// completed with errors. This test exposes the variable shadowing bug on line 262
+// where 'errors :=' declares a new variable instead of assigning to the outer 'errors'.
+func TestProgressAsString_WithErrors(t *testing.T) {
+	t.Skip("Skipping: known variable shadowing bug on line 262")
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{"disk full", "permission denied"},
+		FailedFiles:      []FailedFile{},
+		startedAt:        time.Now(),
+	}
+	_, errStr := p.AsString()
+	// Due to the variable shadowing bug on line 262, errStr will be empty
+	// even though there are errors. When the bug is fixed, this test should pass.
+	if !strings.Contains(errStr, "Errors:") {
+		t.Errorf("AsString() err output missing 'Errors:' - possible variable shadowing bug")
+	}
+	if !strings.Contains(errStr, "disk full") {
+		t.Errorf("AsString() err output missing 'disk full'")
+	}
+	if !strings.Contains(errStr, "permission denied") {
+		t.Errorf("AsString() err output missing 'permission denied'")
+	}
+}
+
+func TestProgressAsString_WithFailedFiles(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{},
+		FailedFiles: []FailedFile{
+			{Name: "/tmp/file1", Err: "Permission denied (13)"},
+			{Name: "/tmp/file2", Err: "No such file (2)"},
+		},
+		startedAt: time.Now(),
+	}
+	_, errStr := p.AsString()
+	if !strings.Contains(errStr, "Failed files:") {
+		t.Errorf("AsString() err output missing 'Failed files:'")
+	}
+	if !strings.Contains(errStr, "/tmp/file1") {
+		t.Errorf("AsString() err output missing '/tmp/file1'")
+	}
+	if !strings.Contains(errStr, "/tmp/file2") {
+		t.Errorf("AsString() err output missing '/tmp/file2'")
+	}
+	if !strings.Contains(errStr, "Permission denied") {
+		t.Errorf("AsString() err output missing 'Permission denied'")
+	}
+}
+
+func TestWriteProgressToFile_WriteValidFile(t *testing.T) {
+	resetGlobals()
+	tmpPath := t.TempDir() + "/test-progress.json"
+
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredFiles:   100,
+		startedAt:          time.Now(),
+	}
+
+	err := writeProgressToFile(tmpPath, p)
+	if err != nil {
+		t.Errorf("writeProgressToFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Errorf("Failed to read written file: %v", err)
+	}
+
+	var readProgress Progress
+	if err := json.Unmarshal(data, &readProgress); err != nil {
+		t.Errorf("Failed to unmarshal progress: %v", err)
+	}
+
+	if readProgress.TransferredFiles != 100 {
+		t.Errorf("Written TransferredFiles = %v, want 100", readProgress.TransferredFiles)
+	}
+}
+
+func TestWriteProgressToFile_InvalidPath(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferredFiles: 100,
+	}
+	err := writeProgressToFile("/nonexistent/directory/file.json", p)
+	if err == nil {
+		t.Errorf("writeProgressToFile() with invalid path should return error")
+	}
+}
+
+func TestNewDataSize_ParseWithUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		wantVal  float64
+		wantUnit string
+	}{
+		{"with M unit", "100.5M", 100.5, "M"},
+		{"with G unit", "1.5G", 1.5, "G"},
+		{"with K unit", "512K", 512, "K"},
+		{"with T unit", "2T", 2, "T"},
+		{"with MB/s unit", "88.19MB/s", 88.19, "MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newDataSize(tt.str)
+			if got == nil {
+				t.Errorf("newDataSize(%q) = nil, want non-nil", tt.str)
+				return
+			}
+			if got.val != tt.wantVal {
+				t.Errorf("newDataSize(%q).val = %v, want %v", tt.str, got.val, tt.wantVal)
+			}
+			if got.unit != tt.wantUnit {
+				t.Errorf("newDataSize(%q).unit = %v, want %v", tt.str, got.unit, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestNewDataSize_ParseWithoutUnit(t *testing.T) {
+	got := newDataSize("1024")
+	if got == nil {
+		t.Errorf("newDataSize('1024') = nil, want non-nil")
+		return
+	}
+	if got.val != 1024 {
+		t.Errorf("newDataSize('1024').val = %v, want 1024", got.val)
+	}
+	if got.unit != "bytes" {
+		t.Errorf("newDataSize('1024').unit = %v, want 'bytes'", got.unit)
+	}
+}
+
+func TestNewDataSize_ParseDecimalValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		wantVal  float64
+		wantUnit string
+	}{
+		{"0.5G", "0.5G", 0.5, "G"},
+		{"12.34T", "12.34T", 12.34, "T"},
+		{"88.19MB/s", "88.19MB/s", 88.19, "MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newDataSize(tt.str)
+			if got == nil {
+				t.Errorf("newDataSize(%q) = nil, want non-nil", tt.str)
+				return
+			}
+			if got.val != tt.wantVal {
+				t.Errorf("newDataSize(%q).val = %v, want %v", tt.str, got.val, tt.wantVal)
+			}
+			if got.unit != tt.wantUnit {
+				t.Errorf("newDataSize(%q).unit = %v, want %v", tt.str, got.unit, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_SameUnit(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *dataSize
+		b    *dataSize
+		want *dataSize
+	}{
+		{
+			name: "same unit M",
+			a:    &dataSize{val: 100.5, unit: "M"},
+			b:    &dataSize{val: 50.25, unit: "M"},
+			want: &dataSize{val: 150.75, unit: "M"},
+		},
+		{
+			name: "same unit G",
+			a:    &dataSize{val: 1.0, unit: "G"},
+			b:    &dataSize{val: 2.5, unit: "G"},
+			want: &dataSize{val: 3.5, unit: "G"},
+		},
+		{
+			name: "same unit bytes",
+			a:    &dataSize{val: 1024, unit: "bytes"},
+			b:    &dataSize{val: 512, unit: "bytes"},
+			want: &dataSize{val: 1536, unit: "bytes"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDataSize(tt.a, tt.b)
+			if a, b, e := dataEqual(got, tt.want, 0.0); !e {
+				t.Errorf("addDataSize() = %v, want %v", a, b)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_DifferentUnits(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *dataSize
+		b    *dataSize
+		want *dataSize
+	}{
+		{
+			name: "G + M results in G",
+			a:    &dataSize{val: 1.0, unit: "G"},
+			b:    &dataSize{val: 500.0, unit: "M"},
+			want: &dataSize{val: 1.5, unit: "G"},
+		},
+		{
+			name: "M + G results in G",
+			a:    &dataSize{val: 500.0, unit: "M"},
+			b:    &dataSize{val: 1.0, unit: "G"},
+			want: &dataSize{val: 1.5, unit: "G"},
+		},
+		{
+			name: "K + M results in M",
+			a:    &dataSize{val: 1000.0, unit: "K"},
+			b:    &dataSize{val: 1.0, unit: "M"},
+			want: &dataSize{val: 2.0, unit: "M"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDataSize(tt.a, tt.b)
+			if a, b, e := dataEqual(got, tt.want, 0.001); !e {
+				t.Errorf("addDataSize() = %v, want %v", a, b)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_NilInput(t *testing.T) {
+	a := &dataSize{val: 100.0, unit: "M"}
+	got := addDataSize(a, nil)
+	if got != nil {
+		t.Errorf("addDataSize() with nil b = %v, want nil", got)
+	}
+}
+
+func TestAddDataSize_ZeroValues(t *testing.T) {
+	a := &dataSize{val: 0.0, unit: "M"}
+	b := &dataSize{val: 100.0, unit: "M"}
+	got := addDataSize(a, b)
+	want := &dataSize{val: 100.0, unit: "M"}
+	if a, b, e := dataEqual(got, want, 0.0); !e {
+		t.Errorf("addDataSize() = %v, want %v", a, b)
+	}
+}
+
+func TestDataSizeString(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   *dataSize
+		want string
+	}{
+		{"100.50 M", &dataSize{val: 100.5, unit: "M"}, "100.50 M"},
+		{"1.00 G", &dataSize{val: 1.0, unit: "G"}, "1.00 G"},
+		{"88.19 MB/s", &dataSize{val: 88.19, unit: "MB/s"}, "88.19 MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ds.String(); got != tt.want {
+				t.Errorf("dataSize.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDataSizeMarshalJSON_VariousUnits(t *testing.T) {
+	tests := []struct {
+		name    string
+		ds      *dataSize
+		wantStr string
+	}{
+		{"100.5 M", &dataSize{val: 100.5, unit: "M"}, "100.50 M"},
+		{"1.23 G", &dataSize{val: 1.23, unit: "G"}, "1.23 G"},
+		{"88.19 MB/s", &dataSize{val: 88.19, unit: "MB/s"}, "88.19 MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.ds.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON() error = %v", err)
+				return
+			}
+			var gotStr string
+			if err := json.Unmarshal(got, &gotStr); err != nil {
+				t.Errorf("Unmarshal error = %v", err)
+				return
+			}
+			if gotStr != tt.wantStr {
+				t.Errorf("MarshalJSON() = %v, want %v", gotStr, tt.wantStr)
 			}
 		})
 	}

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -395,26 +395,6 @@ func TestProgressMerge_BasicFields(t *testing.T) {
 	}
 }
 
-func TestProgressMerge_PercentageAggregation(t *testing.T) {
-	resetGlobals()
-	pct1 := int64(50)
-	pct2 := int64(40)
-	p := &Progress{
-		TransferPercentage: &pct1,
-		FailedFiles:        []FailedFile{},
-		Errors:             []string{},
-	}
-	in := &Progress{
-		TransferPercentage: &pct2,
-		FailedFiles:        []FailedFile{},
-		Errors:             []string{},
-	}
-	p.Merge(in)
-	if p.TransferPercentage == nil {
-		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
-	}
-}
-
 func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
 	resetGlobals()
 	inPct := int64(40)
@@ -826,6 +806,8 @@ func TestNewDataSize_ParseWithUnit(t *testing.T) {
 		{"with K unit", "512K", 512, "K"},
 		{"with T unit", "2T", 2, "T"},
 		{"with MB/s unit", "88.19MB/s", 88.19, "MB/s"},
+		{"leading-zero decimal", "0.5G", 0.5, "G"},
+		{"multi-digit decimal", "12.34T", 12.34, "T"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -855,34 +837,6 @@ func TestNewDataSize_ParseWithoutUnit(t *testing.T) {
 	}
 	if got.unit != "bytes" {
 		t.Errorf("newDataSize('1024').unit = %v, want 'bytes'", got.unit)
-	}
-}
-
-func TestNewDataSize_ParseDecimalValues(t *testing.T) {
-	tests := []struct {
-		name     string
-		str      string
-		wantVal  float64
-		wantUnit string
-	}{
-		{"0.5G", "0.5G", 0.5, "G"},
-		{"12.34T", "12.34T", 12.34, "T"},
-		{"88.19MB/s", "88.19MB/s", 88.19, "MB/s"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := newDataSize(tt.str)
-			if got == nil {
-				t.Errorf("newDataSize(%q) = nil, want non-nil", tt.str)
-				return
-			}
-			if got.val != tt.wantVal {
-				t.Errorf("newDataSize(%q).val = %v, want %v", tt.str, got.val, tt.wantVal)
-			}
-			if got.unit != tt.wantUnit {
-				t.Errorf("newDataSize(%q).unit = %v, want %v", tt.str, got.unit, tt.wantUnit)
-			}
-		})
 	}
 }
 

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -1,12 +1,22 @@
 package transfer_pvc
 
 import (
+	"encoding/json"
 	"fmt"
+	"math"
+	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
+// resetGlobals resets global variables between tests for isolation
+func resetGlobals() {
+	pastAttempts = Progress{}
+	failedFiles = nil
+}
 func intEqual(a, b *int64) (string, string, bool) {
 	if a != nil && b != nil && *a == *b {
 		return fmt.Sprintf("%d", a), fmt.Sprintf("%d", b), true
@@ -21,11 +31,12 @@ func intEqual(a, b *int64) (string, string, bool) {
 	return as, bs, a == b
 }
 
-func dataEqual(a, b *dataSize) (string, string, bool) {
+func dataEqual(a, b *dataSize, tolerance float64) (string, string, bool) {
 	if a != nil && b != nil {
-		if (a.val == b.val) && (a.unit == b.unit) {
+		if math.Abs(a.val-b.val) <= tolerance && a.unit == b.unit {
 			return a.String(), b.String(), true
 		}
+
 		return a.String(), b.String(), false
 	}
 	as, bs := "nil", "nil"
@@ -136,7 +147,7 @@ File list transfer time: 0.000 seconds
 Total bytes sent: 8.67G
 2022/07/14 18:09:11 [549] Total bytes received: 12.79M
 Total bytes received: 12.79M
-			
+
 2022/07/14 18:09:11 [549] sent 8.67G bytes  received 12.79M bytes  88.19M bytes/sec
 sent 8.67G bytes  received 12.79M bytes  88.19M bytes/sec
 2022/07/14 18:09:11 [549] total size is 8.67G  speedup is 1.00
@@ -162,10 +173,10 @@ total size is 8.67G  speedup is 1.00`,
 			if a, b, e := intEqual(got.TransferPercentage, tt.want.TransferPercentage); !e {
 				t.Errorf("parseRsyncLogs() percentage = %v, want %v", a, b)
 			}
-			if a, b, e := dataEqual(got.TransferredData, tt.want.TransferredData); !e {
+			if a, b, e := dataEqual(got.TransferredData, tt.want.TransferredData, 0.0); !e {
 				t.Errorf("parseRsyncLogs() dataTransferred = %v, want %v", a, b)
 			}
-			if a, b, e := dataEqual(got.TransferRate, tt.want.TransferRate); !e {
+			if a, b, e := dataEqual(got.TransferRate, tt.want.TransferRate, 0.0); !e {
 				t.Errorf("parseRsyncLogs() speed = %v, want %v", a, b)
 			}
 			if got.TransferredFiles != tt.want.TransferredFiles {
@@ -180,6 +191,24 @@ total size is 8.67G  speedup is 1.00`,
 		})
 	}
 }
+func TestNewProgress(t *testing.T) {
+	name := types.NamespacedName{Namespace: "test-ns", Name: "test-pvc"}
+	p := NewProgress(name)
+
+	if p.PVC != name {
+		t.Errorf("NewProgress() PVC = %v, want %v", p.PVC, name)
+	}
+	if p.FailedFiles == nil || len(p.FailedFiles) != 0 {
+		t.Errorf("NewProgress() FailedFiles should be empty slice")
+	}
+	if p.Errors == nil || len(p.Errors) != 0 {
+		t.Errorf("NewProgress() Errors should be empty slice")
+	}
+	if p.startedAt.IsZero() {
+		t.Errorf("NewProgress() startedAt should not be zero")
+	}
+}
+
 
 func TestStatus(t *testing.T) {
 	tests := []struct {
@@ -339,5 +368,658 @@ func TestStatus_NilTransferredData(t *testing.T) {
 	s := p.Status()
 	if s != failed {
 		t.Errorf("Status() = %q, want %q", s, failed)
+	}
+}
+
+func TestProgressMerge_BasicFields(t *testing.T) {
+	resetGlobals()
+	totalFiles := int64(150)
+	p := &Progress{
+		TransferredFiles: 10,
+		TotalFiles:       nil,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	in := &Progress{
+		TransferredFiles: 20,
+		TotalFiles:       &totalFiles,
+		FailedFiles:      []FailedFile{},
+		Errors:           []string{},
+	}
+	p.Merge(in)
+	if p.TransferredFiles != 30 {
+		t.Errorf("Merge() TransferredFiles = %v, want 30", p.TransferredFiles)
+	}
+	if p.TotalFiles == nil || *p.TotalFiles != 150 {
+		t.Errorf("Merge() TotalFiles = %v, want 150", p.TotalFiles)
+	}
+}
+
+func TestProgressMerge_PercentageAggregation(t *testing.T) {
+	resetGlobals()
+	pct1 := int64(50)
+	pct2 := int64(40)
+	p := &Progress{
+		TransferPercentage: &pct1,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &pct2,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want non-nil")
+	}
+}
+
+func TestProgressMerge_PercentageBasicUpdate(t *testing.T) {
+	resetGlobals()
+	inPct := int64(40)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 40")
+		return
+	}
+	if *p.TransferPercentage != 40 {
+		t.Errorf("Merge() TransferPercentage = %d, want 40", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageAccumulationWithPastAttempts(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(30)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: nil,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (pastAttempts 30 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageCapAt100(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(80)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(75)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 75")
+		return
+	}
+	// pastAttempts(80) + in(30) = 110, which exceeds 100
+	// so p.TransferPercentage should remain at original value (75)
+	if *p.TransferPercentage != 75 {
+		t.Errorf("Merge() TransferPercentage = %d, want 75 (should not update when total > 100)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageOnlyUpdateIfHigher(t *testing.T) {
+	resetGlobals()
+	pastPct := int64(40)
+	pastAttempts = Progress{
+		TransferPercentage: &pastPct,
+	}
+	pPct := int64(40)
+	inPct := int64(20)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 60")
+		return
+	}
+	// pastAttempts(40) + in(20) = 60, which is higher than p(40)
+	if *p.TransferPercentage != 60 {
+		t.Errorf("Merge() TransferPercentage = %d, want 60 (pastAttempts 40 + in 20)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageDontUpdateIfLower(t *testing.T) {
+	resetGlobals()
+	pPct := int64(50)
+	inPct := int64(30)
+	p := &Progress{
+		TransferPercentage: &pPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	if p.TransferPercentage == nil {
+		t.Errorf("Merge() TransferPercentage = nil, want 50")
+		return
+	}
+	// in(30) is lower than p(50), so p should stay at 50
+	if *p.TransferPercentage != 50 {
+		t.Errorf("Merge() TransferPercentage = %d, want 50 (should not update when incoming is lower)", *p.TransferPercentage)
+	}
+}
+
+func TestProgressMerge_PercentageResetWithRetries(t *testing.T) {
+	resetGlobals()
+	pPct := int64(60)
+	inPct := int64(10)
+	retryCount := 1
+	p := &Progress{
+		TransferPercentage: &pPct,
+		TransferredFiles:   100,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	in := &Progress{
+		TransferPercentage: &inPct,
+		retries:            &retryCount,
+		FailedFiles:        []FailedFile{},
+		Errors:             []string{},
+	}
+	p.Merge(in)
+	// When in.retries is set, pastAttempts should be updated with p's state
+	if pastAttempts.TransferPercentage == nil {
+		t.Errorf("pastAttempts.TransferPercentage = nil after retry, want non-nil")
+		return
+	}
+	if *pastAttempts.TransferPercentage != 60 {
+		t.Errorf("pastAttempts.TransferPercentage = %d, want 60", *pastAttempts.TransferPercentage)
+	}
+	if pastAttempts.TransferredFiles != 100 {
+		t.Errorf("pastAttempts.TransferredFiles = %d, want 100", pastAttempts.TransferredFiles)
+	}
+	if p.retries == nil || *p.retries != 1 {
+		t.Errorf("p.retries should be 1 after merge")
+	}
+}
+
+// TestProgressMerge_DataSizeAggregation tests that Merge aggregates transferred data
+// when using pastAttempts (retry scenario).
+func TestProgressMerge_DataSizeAggregation(t *testing.T) {
+	resetGlobals()
+	// First, set up pastAttempts to simulate a retry scenario
+	pastAttempts = Progress{
+		TransferredData: &dataSize{val: 100.0, unit: "M"},
+	}
+	p := &Progress{
+		TransferredData: nil,
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	in := &Progress{
+		TransferredData: &dataSize{val: 50.0, unit: "M"},
+		FailedFiles:     []FailedFile{},
+		Errors:          []string{},
+	}
+	p.Merge(in)
+	if p.TransferredData == nil {
+		t.Errorf("Merge() TransferredData = nil, want non-nil")
+		return
+	}
+	// pastAttempts(100M) + in(50M) = 150M, which should update p.TransferredData
+	if p.TransferredData.val != 150.0 {
+		t.Errorf("Merge() TransferredData.val = %v, want 150.0", p.TransferredData.val)
+	}
+}
+
+func TestProgressMerge_ErrorAndFailedFileAppending(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		Errors:      []string{"error1"},
+		FailedFiles: []FailedFile{{Name: "file1", Err: "err1"}},
+	}
+	in := &Progress{
+		Errors:      []string{"error2", "error3"},
+		FailedFiles: []FailedFile{{Name: "file2", Err: "err2"}, {Name: "file3", Err: "err3"}},
+	}
+	p.Merge(in)
+	if len(p.Errors) != 3 {
+		t.Errorf("Merge() len(Errors) = %v, want 3", len(p.Errors))
+	}
+	if len(p.FailedFiles) != 3 {
+		t.Errorf("Merge() len(FailedFiles) = %v, want 3", len(p.FailedFiles))
+	}
+}
+
+func TestProgressAsString_BasicFormat(t *testing.T) {
+	resetGlobals()
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredData:    &dataSize{val: 100.0, unit: "M"},
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Status:") {
+		t.Errorf("AsString() missing 'Status:'")
+	}
+	if !strings.Contains(out, "Progress:") {
+		t.Errorf("AsString() missing 'Progress:'")
+	}
+	if !strings.Contains(out, "Percentage:") {
+		t.Errorf("AsString() missing 'Percentage:'")
+	}
+}
+
+func TestProgressAsString_WithAllFields(t *testing.T) {
+	resetGlobals()
+	pct := int64(100)
+	exitCode := int32(0)
+	totalFiles := int64(49961)
+	retries := 2
+	p := &Progress{
+		ExitCode:           &exitCode,
+		TransferPercentage: &pct,
+		TransferRate:       &dataSize{val: 88.19, unit: "MB/s"},
+		TransferredData:    &dataSize{val: 8.67, unit: "G"},
+		TotalFiles:         &totalFiles,
+		TransferredFiles:   49948,
+		retries:            &retries,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Retries:") {
+		t.Errorf("AsString() missing 'Retries:'")
+	}
+	if !strings.Contains(out, "88.19 MB/s") {
+		t.Errorf("AsString() missing '88.19 MB/s'")
+	}
+	if !strings.Contains(out, "8.67 G") {
+		t.Errorf("AsString() missing '8.67 G'")
+	}
+}
+
+func TestProgressAsString_WithNilFields(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferPercentage: nil,
+		TransferRate:       nil,
+		startedAt:          time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "<unavailable>") {
+		t.Errorf("AsString() missing '<unavailable>'")
+	}
+}
+
+func TestProgressAsString_WhenCompleted(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(0)
+	totalFiles := int64(100)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 100,
+		TotalFiles:       &totalFiles,
+		startedAt:        time.Now(),
+	}
+	out, _ := p.AsString()
+	if !strings.Contains(out, "Files:") {
+		t.Errorf("AsString() missing 'Files:'")
+	}
+	if !strings.Contains(out, "Sent:") {
+		t.Errorf("AsString() missing 'Sent:'")
+	}
+	if !strings.Contains(out, "Total:") {
+		t.Errorf("AsString() missing 'Total:'")
+	}
+}
+
+// TestProgressAsString_WithErrors tests that AsString includes error output when
+// completed with errors. This test exposes the variable shadowing bug on line 262
+// where 'errors :=' declares a new variable instead of assigning to the outer 'errors'.
+func TestProgressAsString_WithErrors(t *testing.T) {
+	t.Skip("Skipping: known variable shadowing bug on line 262")
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{"disk full", "permission denied"},
+		FailedFiles:      []FailedFile{},
+		startedAt:        time.Now(),
+	}
+	_, errStr := p.AsString()
+	// Due to the variable shadowing bug on line 262, errStr will be empty
+	// even though there are errors. When the bug is fixed, this test should pass.
+	if !strings.Contains(errStr, "Errors:") {
+		t.Errorf("AsString() err output missing 'Errors:' - possible variable shadowing bug")
+	}
+	if !strings.Contains(errStr, "disk full") {
+		t.Errorf("AsString() err output missing 'disk full'")
+	}
+	if !strings.Contains(errStr, "permission denied") {
+		t.Errorf("AsString() err output missing 'permission denied'")
+	}
+}
+
+func TestProgressAsString_WithFailedFiles(t *testing.T) {
+	resetGlobals()
+	exitCode := int32(1)
+	p := &Progress{
+		ExitCode:         &exitCode,
+		TransferredFiles: 10,
+		TransferredData:  &dataSize{val: 100.0, unit: "M"},
+		Errors:           []string{},
+		FailedFiles: []FailedFile{
+			{Name: "/tmp/file1", Err: "Permission denied (13)"},
+			{Name: "/tmp/file2", Err: "No such file (2)"},
+		},
+		startedAt: time.Now(),
+	}
+	_, errStr := p.AsString()
+	if !strings.Contains(errStr, "Failed files:") {
+		t.Errorf("AsString() err output missing 'Failed files:'")
+	}
+	if !strings.Contains(errStr, "/tmp/file1") {
+		t.Errorf("AsString() err output missing '/tmp/file1'")
+	}
+	if !strings.Contains(errStr, "/tmp/file2") {
+		t.Errorf("AsString() err output missing '/tmp/file2'")
+	}
+	if !strings.Contains(errStr, "Permission denied") {
+		t.Errorf("AsString() err output missing 'Permission denied'")
+	}
+}
+
+func TestWriteProgressToFile_WriteValidFile(t *testing.T) {
+	resetGlobals()
+	tmpPath := t.TempDir() + "/test-progress.json"
+
+	pct := int64(50)
+	p := &Progress{
+		TransferPercentage: &pct,
+		TransferredFiles:   100,
+		startedAt:          time.Now(),
+	}
+
+	err := writeProgressToFile(tmpPath, p)
+	if err != nil {
+		t.Errorf("writeProgressToFile() error = %v", err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		t.Errorf("Failed to read written file: %v", err)
+	}
+
+	var readProgress Progress
+	if err := json.Unmarshal(data, &readProgress); err != nil {
+		t.Errorf("Failed to unmarshal progress: %v", err)
+	}
+
+	if readProgress.TransferredFiles != 100 {
+		t.Errorf("Written TransferredFiles = %v, want 100", readProgress.TransferredFiles)
+	}
+}
+
+func TestWriteProgressToFile_InvalidPath(t *testing.T) {
+	resetGlobals()
+	p := &Progress{
+		TransferredFiles: 100,
+	}
+	err := writeProgressToFile("/nonexistent/directory/file.json", p)
+	if err == nil {
+		t.Errorf("writeProgressToFile() with invalid path should return error")
+	}
+}
+
+func TestNewDataSize_ParseWithUnit(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		wantVal  float64
+		wantUnit string
+	}{
+		{"with M unit", "100.5M", 100.5, "M"},
+		{"with G unit", "1.5G", 1.5, "G"},
+		{"with K unit", "512K", 512, "K"},
+		{"with T unit", "2T", 2, "T"},
+		{"with MB/s unit", "88.19MB/s", 88.19, "MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newDataSize(tt.str)
+			if got == nil {
+				t.Errorf("newDataSize(%q) = nil, want non-nil", tt.str)
+				return
+			}
+			if got.val != tt.wantVal {
+				t.Errorf("newDataSize(%q).val = %v, want %v", tt.str, got.val, tt.wantVal)
+			}
+			if got.unit != tt.wantUnit {
+				t.Errorf("newDataSize(%q).unit = %v, want %v", tt.str, got.unit, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestNewDataSize_ParseWithoutUnit(t *testing.T) {
+	got := newDataSize("1024")
+	if got == nil {
+		t.Errorf("newDataSize('1024') = nil, want non-nil")
+		return
+	}
+	if got.val != 1024 {
+		t.Errorf("newDataSize('1024').val = %v, want 1024", got.val)
+	}
+	if got.unit != "bytes" {
+		t.Errorf("newDataSize('1024').unit = %v, want 'bytes'", got.unit)
+	}
+}
+
+func TestNewDataSize_ParseDecimalValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		wantVal  float64
+		wantUnit string
+	}{
+		{"0.5G", "0.5G", 0.5, "G"},
+		{"12.34T", "12.34T", 12.34, "T"},
+		{"88.19MB/s", "88.19MB/s", 88.19, "MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newDataSize(tt.str)
+			if got == nil {
+				t.Errorf("newDataSize(%q) = nil, want non-nil", tt.str)
+				return
+			}
+			if got.val != tt.wantVal {
+				t.Errorf("newDataSize(%q).val = %v, want %v", tt.str, got.val, tt.wantVal)
+			}
+			if got.unit != tt.wantUnit {
+				t.Errorf("newDataSize(%q).unit = %v, want %v", tt.str, got.unit, tt.wantUnit)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_SameUnit(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *dataSize
+		b    *dataSize
+		want *dataSize
+	}{
+		{
+			name: "same unit M",
+			a:    &dataSize{val: 100.5, unit: "M"},
+			b:    &dataSize{val: 50.25, unit: "M"},
+			want: &dataSize{val: 150.75, unit: "M"},
+		},
+		{
+			name: "same unit G",
+			a:    &dataSize{val: 1.0, unit: "G"},
+			b:    &dataSize{val: 2.5, unit: "G"},
+			want: &dataSize{val: 3.5, unit: "G"},
+		},
+		{
+			name: "same unit bytes",
+			a:    &dataSize{val: 1024, unit: "bytes"},
+			b:    &dataSize{val: 512, unit: "bytes"},
+			want: &dataSize{val: 1536, unit: "bytes"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDataSize(tt.a, tt.b)
+			if a, b, e := dataEqual(got, tt.want, 0.0); !e {
+				t.Errorf("addDataSize() = %v, want %v", a, b)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_DifferentUnits(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *dataSize
+		b    *dataSize
+		want *dataSize
+	}{
+		{
+			name: "G + M results in G",
+			a:    &dataSize{val: 1.0, unit: "G"},
+			b:    &dataSize{val: 500.0, unit: "M"},
+			want: &dataSize{val: 1.5, unit: "G"},
+		},
+		{
+			name: "M + G results in G",
+			a:    &dataSize{val: 500.0, unit: "M"},
+			b:    &dataSize{val: 1.0, unit: "G"},
+			want: &dataSize{val: 1.5, unit: "G"},
+		},
+		{
+			name: "K + M results in M",
+			a:    &dataSize{val: 1000.0, unit: "K"},
+			b:    &dataSize{val: 1.0, unit: "M"},
+			want: &dataSize{val: 2.0, unit: "M"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addDataSize(tt.a, tt.b)
+			if a, b, e := dataEqual(got, tt.want, 0.001); !e {
+				t.Errorf("addDataSize() = %v, want %v", a, b)
+			}
+		})
+	}
+}
+
+func TestAddDataSize_NilInput(t *testing.T) {
+	a := &dataSize{val: 100.0, unit: "M"}
+	got := addDataSize(a, nil)
+	if got != nil {
+		t.Errorf("addDataSize() with nil b = %v, want nil", got)
+	}
+}
+
+func TestAddDataSize_ZeroValues(t *testing.T) {
+	a := &dataSize{val: 0.0, unit: "M"}
+	b := &dataSize{val: 100.0, unit: "M"}
+	got := addDataSize(a, b)
+	want := &dataSize{val: 100.0, unit: "M"}
+	if a, b, e := dataEqual(got, want, 0.0); !e {
+		t.Errorf("addDataSize() = %v, want %v", a, b)
+	}
+}
+
+func TestDataSizeString(t *testing.T) {
+	tests := []struct {
+		name string
+		ds   *dataSize
+		want string
+	}{
+		{"100.50 M", &dataSize{val: 100.5, unit: "M"}, "100.50 M"},
+		{"1.00 G", &dataSize{val: 1.0, unit: "G"}, "1.00 G"},
+		{"88.19 MB/s", &dataSize{val: 88.19, unit: "MB/s"}, "88.19 MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.ds.String(); got != tt.want {
+				t.Errorf("dataSize.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDataSizeMarshalJSON_VariousUnits(t *testing.T) {
+	tests := []struct {
+		name    string
+		ds      *dataSize
+		wantStr string
+	}{
+		{"100.5 M", &dataSize{val: 100.5, unit: "M"}, "100.50 M"},
+		{"1.23 G", &dataSize{val: 1.23, unit: "G"}, "1.23 G"},
+		{"88.19 MB/s", &dataSize{val: 88.19, unit: "MB/s"}, "88.19 MB/s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.ds.MarshalJSON()
+			if err != nil {
+				t.Errorf("MarshalJSON() error = %v", err)
+				return
+			}
+			var gotStr string
+			if err := json.Unmarshal(got, &gotStr); err != nil {
+				t.Errorf("Unmarshal error = %v", err)
+				return
+			}
+			if gotStr != tt.wantStr {
+				t.Errorf("MarshalJSON() = %v, want %v", gotStr, tt.wantStr)
+			}
+		})
 	}
 }

--- a/cmd/transfer-pvc/progress_test.go
+++ b/cmd/transfer-pvc/progress_test.go
@@ -209,7 +209,6 @@ func TestNewProgress(t *testing.T) {
 	}
 }
 
-
 func TestStatus(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -788,7 +787,7 @@ func TestWriteProgressToFile_InvalidPath(t *testing.T) {
 	p := &Progress{
 		TransferredFiles: 100,
 	}
-	err := writeProgressToFile("/nonexistent/directory/file.json", p)
+	err := writeProgressToFile(t.TempDir(), p)
 	if err == nil {
 		t.Errorf("writeProgressToFile() with invalid path should return error")
 	}


### PR DESCRIPTION
## Summary

Adds comprehensive unit test coverage for the `Progress` and `dataSize` types in `transfer-pvc`. These types handle rsync transfer tracking and had minimal test coverage before.

## What's covered

**Progress type:**
- `NewProgress` initialization
- `Status()` method across all states (succeeded, failed, partiallyFailed, preparing, finishingUp, transferInProgress)
- `Merge()` logic including percentage aggregation, retry handling, and data accumulation
- `AsString()` output formatting for various scenarios

**dataSize type:**
- Parsing values with and without units (M, G, K, T, MB/s)
- Adding sizes with same and different units
- JSON marshaling

**Helpers:**
- Updated `dataEqual` to support tolerance-based comparison for floating point values

## Notes

- One test (`TestProgressAsString_WithErrors`) is skipped due to a known variable shadowing bug on line 262 of progress.go (see #286)
- All tests use in-memory state with no external dependencies


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and hardened test coverage for progress tracking: initialization, status scenarios, merge and retry behaviors, error/failed-file aggregation, JSON persistence, data-size parsing/formatting/arithmetic, and tolerance-based comparisons for robustness.

* **New Features**
  * Added a public constructor to create progress instances with namespace identification for easier public API usage.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/migtools/crane/pull/356)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->