### PR TITLE
bugfix/fix impersonation headers export

### DIFF
--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -172,6 +172,21 @@ func allResourceListsForbidden(resources []*groupResource, resourceErrs []*group
 	return true
 }
 
+// mergeImpersonationExtras merges src into dest, appending values for shared keys.
+// This preserves extras already set by ToRESTConfig() alongside --as-extras flag values.
+func mergeImpersonationExtras(dest, src map[string][]string) map[string][]string {
+	if len(src) == 0 {
+		return dest
+	}
+	if dest == nil {
+		return src
+	}
+	for k, v := range src {
+		dest[k] = append(dest[k], v...)
+	}
+	return dest
+}
+
 // Run performs discovery, lists resources, filters cluster-scoped RBAC to related
 // ServiceAccounts, writes YAML under exportDir, and returns an aggregate of non-fatal write errors.
 func (o *ExportOptions) Run() error {
@@ -185,17 +200,7 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
-	// Merge o.extras into restConfig.Impersonate.Extra instead of overwriting,
-	// so --as-user-extra values from ToRESTConfig() are preserved alongside --as-extras.
-	if o.extras != nil {
-		if restConfig.Impersonate.Extra == nil {
-			restConfig.Impersonate.Extra = o.extras
-		} else {
-			for k, v := range o.extras {
-				restConfig.Impersonate.Extra[k] = append(restConfig.Impersonate.Extra[k], v...)
-			}
-		}
-	}
+	restConfig.Impersonate.Extra = mergeImpersonationExtras(restConfig.Impersonate.Extra, o.extras)
 	restConfig.Burst = o.Burst
 	restConfig.QPS = o.QPS
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -185,8 +185,17 @@ func (o *ExportOptions) Run() error {
 		return err
 	}
 
-	// user/group impersonation is handled from genericclioptions.ConfigFlags
-	restConfig.Impersonate.Extra = o.extras
+	// Merge o.extras into restConfig.Impersonate.Extra instead of overwriting,
+	// so --as-user-extra values from ToRESTConfig() are preserved alongside --as-extras.
+	if o.extras != nil {
+		if restConfig.Impersonate.Extra == nil {
+			restConfig.Impersonate.Extra = o.extras
+		} else {
+			for k, v := range o.extras {
+				restConfig.Impersonate.Extra[k] = append(restConfig.Impersonate.Extra[k], v...)
+			}
+		}
+	}
 	restConfig.Burst = o.Burst
 	restConfig.QPS = o.QPS
 

--- a/cmd/export/export_test.go
+++ b/cmd/export/export_test.go
@@ -470,6 +470,79 @@ func TestExport_HelpGroupsFlags(t *testing.T) {
 	}
 }
 
+func TestMergeImpersonationExtras(t *testing.T) {
+	tests := []struct {
+		name string
+		dest map[string][]string
+		src  map[string][]string
+		want map[string][]string
+	}{
+		{
+			name: "both nil",
+			dest: nil,
+			src:  nil,
+			want: nil,
+		},
+		{
+			name: "src nil dest non-nil",
+			dest: map[string][]string{"k1": {"v1"}},
+			src:  nil,
+			want: map[string][]string{"k1": {"v1"}},
+		},
+		{
+			name: "dest nil src non-nil",
+			dest: nil,
+			src:  map[string][]string{"k1": {"v1"}},
+			want: map[string][]string{"k1": {"v1"}},
+		},
+		{
+			name: "distinct keys both preserved",
+			dest: map[string][]string{"from-config": {"a"}},
+			src:  map[string][]string{"from-flag": {"b"}},
+			want: map[string][]string{"from-config": {"a"}, "from-flag": {"b"}},
+		},
+		{
+			name: "overlapping key values appended not overwritten",
+			dest: map[string][]string{"key": {"existing"}},
+			src:  map[string][]string{"key": {"new"}},
+			want: map[string][]string{"key": {"existing", "new"}},
+		},
+		{
+			name: "overlapping and distinct keys",
+			dest: map[string][]string{"shared": {"from-config"}, "config-only": {"val1"}},
+			src:  map[string][]string{"shared": {"from-extras"}, "extras-only": {"val2"}},
+			want: map[string][]string{
+				"shared":      {"from-config", "from-extras"},
+				"config-only": {"val1"},
+				"extras-only": {"val2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeImpersonationExtras(tt.dest, tt.src)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for k, wantV := range tt.want {
+				gotV, ok := got[k]
+				if !ok {
+					t.Fatalf("missing key %q in result", k)
+				}
+				if len(gotV) != len(wantV) {
+					t.Fatalf("got[%q] = %v, want %v", k, gotV, wantV)
+				}
+				for i := range wantV {
+					if gotV[i] != wantV[i] {
+						t.Fatalf("got[%q][%d] = %q, want %q", k, i, gotV[i], wantV[i])
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestAllResourceListsForbidden(t *testing.T) {
 	forbiddenErr := apierrors.NewForbidden(
 		schema.GroupResource{Resource: "configmaps"},


### PR DESCRIPTION

Fixes [#416](https://github.com/migtools/crane/issues/416)

### Description
When both native Kubernetes impersonation flags (`--as-user-extra`) and crane's custom flag (`--as-extras`) were used together, the native configuration map was being completely overwritten and lost due to a direct map assignment.

This PR safely replaces the direct assignment with a key-by-key map merge in `cmd/export/export.go`, ensuring both sets of impersonation headers are preserved and correctly sent to the API server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved impersonation handling during export so existing extra impersonation values are preserved instead of being overwritten.
  * Export commands now combine all provided impersonation extras, including values set earlier and values passed on the command line.
* **Tests**
  * Added unit coverage to verify correct merging behavior for impersonation extras, including nil-map and slice-append semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->