### PR TITLE
:test_tube:  Add tier0/tier1 RBAC e2e tests (MTA-856, MTA-866, MTA-867)

### DIFF
--- a/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
@@ -1,0 +1,92 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Namespace-admin cluster-level migration", func() {
+	It("[NA-4] Should migrate namespace-only workload as namespace-admin without split apply", Label("tier0"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		if scenario.KubectlSrcNonAdmin.Context == "" {
+			Skip("source-nonadmin-context is required for non-admin role migration test")
+		}
+		if scenario.KubectlTgtNonAdmin.Context == "" {
+			Skip("target-nonadmin-context is required for non-admin role migration test")
+		}
+		srcAppNonAdmin := scenario.SrcAppNonAdmin
+		tgtAppNonAdmin := scenario.TgtAppNonAdmin
+
+		srcAppNonAdmin.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtAppNonAdmin.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+
+		runner := scenario.CraneNonAdmin
+		kubectlTgt := scenario.KubectlTgt
+		paths, err := NewScenarioPaths("crane-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		exportOpts := ExportOptions{Namespace: srcAppNonAdmin.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		By("Granting namespace-admin permissions to non-admin user on source and target")
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(rbacCleanup)
+		DeferCleanup(func() {
+			rbacCleanup()
+
+			if err := CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+
+		})
+
+		By("Deploying namespace-only app as namespace-admin on source cluster")
+		err = PrepareSourceApp(srcAppNonAdmin, kubectlSrcNonAdmin)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrcNonAdmin, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply as namespace-admin")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no cluster resources was migrated")
+		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
+		_, _, err = utils.HasFilesRecursively(clusterDir)
+		//we dont expct orphan cr's to be migrated,so _cluster dir should not be created.
+		Expect(err).To(HaveOccurred())
+
+		By("Applying namespace resources to target as namespace-admin")
+		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir))).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtAppNonAdmin.Validate, "2m", "10s").Should(Succeed())
+
+	})
+
+})

--- a/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Namespace-admin cluster-level migration", func() {
-	It("[NA-4] Should migrate namespace-only workload as namespace-admin without split apply", Label("tier0"), func() {
+	It("[MTA-866] Should migrate namespace-only workload as namespace-admin without split apply", Label("tier0"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName
@@ -24,12 +24,6 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 			config.SourceContext,
 			config.TargetContext,
 		)
-		if scenario.KubectlSrcNonAdmin.Context == "" {
-			Skip("source-nonadmin-context is required for non-admin role migration test")
-		}
-		if scenario.KubectlTgtNonAdmin.Context == "" {
-			Skip("target-nonadmin-context is required for non-admin role migration test")
-		}
 		srcAppNonAdmin := scenario.SrcAppNonAdmin
 		tgtAppNonAdmin := scenario.TgtAppNonAdmin
 
@@ -41,7 +35,6 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		}
 
 		runner := scenario.CraneNonAdmin
-		kubectlTgt := scenario.KubectlTgt
 		paths, err := NewScenarioPaths("crane-*")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -51,10 +44,8 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 			OutputDir: paths.OutputDir}
 
 		By("Granting namespace-admin permissions to non-admin user on source and target")
-		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupNamespaceAdminUsersForScenario(scenario, namespace)
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
-
-		DeferCleanup(rbacCleanup)
 		DeferCleanup(func() {
 			rbacCleanup()
 
@@ -77,11 +68,11 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		By("Verifying no cluster resources was migrated")
 		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
 		_, _, err = utils.HasFilesRecursively(clusterDir)
-		//we dont expct orphan cr's to be migrated,so _cluster dir should not be created.
+		//no cluster resurces-> no _cluster folder created ->we expect an error.
 		Expect(err).To(HaveOccurred())
 
 		By("Applying namespace resources to target as namespace-admin")
-		Expect(kubectlTgt.ApplyDir(filepath.Join(paths.OutputDir))).NotTo(HaveOccurred())
+		Expect(kubectlTgtNonAdmin.ApplyDir(filepath.Join(paths.OutputDir))).NotTo(HaveOccurred())
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
@@ -46,13 +46,12 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 		kubectlSrcNonAdmin, kubectlTgtNonAdmin, rbacCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() {
-			rbacCleanup()
-
 			if err := CleanupScenario(paths.TempDir, srcAppNonAdmin, tgtAppNonAdmin); err != nil {
 				log.Printf("Scenario cleanup: %v", err)
 			}
-
 		})
+
+		DeferCleanup(rbacCleanup)
 
 		By("Deploying namespace-only app as namespace-admin on source cluster")
 		err = PrepareSourceApp(srcAppNonAdmin, kubectlSrcNonAdmin)
@@ -66,11 +65,11 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		By("Verifying no cluster resources was migrated")
 		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
-		//no cluster resurces-> no _cluster folder created ->we expect an error.
+		//no cluster resources-> no _cluster folder created ->we expect an error.
 		Expect(clusterDir).NotTo(BeADirectory())
 
 		By("Applying namespace resources to target as namespace-admin")
-		Expect(kubectlTgtNonAdmin.ApplyDir(filepath.Join(paths.OutputDir))).NotTo(HaveOccurred())
+		Expect(kubectlTgtNonAdmin.ApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("Scaling target deployment and validating app")
 		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/konveyor/crane/e2e-tests/config"
 	. "github.com/konveyor/crane/e2e-tests/framework"
-	"github.com/konveyor/crane/e2e-tests/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -67,9 +66,8 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		By("Verifying no cluster resources was migrated")
 		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
-		_, _, err = utils.HasFilesRecursively(clusterDir)
 		//no cluster resurces-> no _cluster folder created ->we expect an error.
-		Expect(err).To(HaveOccurred())
+		Expect(clusterDir).NotTo(BeADirectory())
 
 		By("Applying namespace resources to target as namespace-admin")
 		Expect(kubectlTgtNonAdmin.ApplyDir(filepath.Join(paths.OutputDir))).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
+++ b/e2e-tests/tests/tier0/mta_866_na_no_cluster_resources_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Namespace-admin cluster-level migration", func() {
 
 		exportOpts := ExportOptions{Namespace: srcAppNonAdmin.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
-		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
 
 		By("Granting namespace-admin permissions to non-admin user on source and target")

--- a/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
@@ -59,10 +59,10 @@ var _ = Describe("Cluster-level RBAC export", func() {
 		By("Deploying app on source cluster")
 		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating Creating first Service-account on src namespace")
+		By("Creating first Service-account on src namespace")
 		Expect(firstSa.Create(kubectlSrc)).NotTo(HaveOccurred())
 
-		By("Creating Creating second Service-account on src namespace")
+		By("Creating second Service-account on src namespace")
 		Expect(secondSa.Create(kubectlSrc)).NotTo(HaveOccurred())
 
 		By("Creating ClusterRole on source cluster")

--- a/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
@@ -1,0 +1,108 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level RBAC export", func() {
+	It("[MTA-856] Should export ClusterRole and ClusterRoleBinding for linked ServiceAccount", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		firstSa := ServiceAccount{Name: "first-sa", Namespace: namespace}
+		secondSa := ServiceAccount{Name: "second-sa", Namespace: namespace}
+		firstSubject := "--serviceaccount=" + namespace + ":" + firstSa.Name
+		secondSubject := "--serviceaccount=" + namespace + ":" + secondSa.Name
+
+		cr := ClusterRole{Name: "crane-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+		crb1 := ClusterRoleBinding{Name: "first-crb", ClusterRoleName: cr.Name, Subject: firstSubject}
+		crb2 := ClusterRoleBinding{Name: "second-crb", ClusterRoleName: cr.Name, Subject: secondSubject}
+		tgtNamespace := Namespace{Name: namespace}
+
+		DeferCleanup(func() {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{cr, crb1, crb2, firstSa, secondSa, tgtNamespace}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+		})
+
+		By("Deploying app on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Creating first Service-account on src namespace")
+		Expect(firstSa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating Creating second Service-account on src namespace")
+		Expect(secondSa.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating ClusterRole on source cluster")
+		Expect(cr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating first ClusterRoleBinding referencing first ServiceAccount")
+		Expect(crb1.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating second ClusterRoleBinding referencing second ServiceAccount")
+		Expect(crb2.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
+
+		By("Create Namespace On target cluster")
+		Expect(tgtNamespace.Create(kubectlTgt)).NotTo(HaveOccurred())
+
+		By("Dry-run applying output manifests on target")
+		Expect(kubectlTgt.ValidateApplyDir(paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Applying migrated manifests to target cluster")
+		Expect(ApplyOutputToTarget(kubectlTgt, tgtNamespace.Name, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scaling target deployment and validating app")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace.Name, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "2m", "10s").Should(Succeed())
+
+		By("Verifying both ClusterRoleBindings on target reference correct ClusterRole and ServiceAccounts")
+		Expect(ValidateClusterRBAC(kubectlTgt, []ExpectedClusterRoleBinding{
+			{ClusterRoleBindingName: crb1.Name, ClusterRoleName: crb1.ClusterRoleName, SubjectName: firstSa.Name},
+			{ClusterRoleBindingName: crb2.Name, ClusterRoleName: crb2.ClusterRoleName, SubjectName: secondSa.Name},
+		})).NotTo(HaveOccurred())
+	})
+})

--- a/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
+++ b/e2e-tests/tests/tier1/mta_856_multiple_crbs_minimal_rbac_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Cluster-level RBAC export", func() {
 
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
-		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
 
 		firstSa := ServiceAccount{Name: "first-sa", Namespace: namespace}

--- a/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
+++ b/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
@@ -1,0 +1,70 @@
+package e2e
+
+import (
+	"log"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster-level export filtering", func() {
+	It("[CA-6] Should not export orphan ClusterRole with no CRB linking it to exported SAs", Label("tier1"), func() {
+		appName := "simple-nginx-nopv"
+		namespace := "simple-nginx-nopv"
+		serviceName := "my-" + appName
+
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+		paths, err := NewScenarioPaths("crane-*")
+		Expect(err).NotTo(HaveOccurred())
+		orphanedcr := ClusterRole{Name: "orphaned-cr", Verb: "get,list,watch,create,update,delete", Resource: "pods"}
+
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+			OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			if err := ResourceCleanup([]KubectlRunner{kubectlSrc, kubectlTgt}, []Resource{orphanedcr}); err != nil {
+				log.Printf("Resources cleanup: %v", err)
+			}
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("Scenario cleanup: %v", err)
+			}
+		})
+
+		By("Deploying app with ServiceAccount on source cluster")
+		Expect(PrepareSourceApp(srcApp, kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Creating orphan ClusterRole with pod write permissions (no CRB)")
+		Expect(orphanedcr.Create(kubectlSrc)).NotTo(HaveOccurred())
+
+		By("Waiting for source pods and endpoints to drain")
+		WaitForSourceQuiesce(kubectlSrc, namespace, "app="+appName, serviceName)
+
+		By("Running crane export, transform, apply")
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Verifying orphan ClusterRole Didnot migrate")
+		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
+		_, _, err = utils.HasFilesRecursively(clusterDir)
+		//we dont expct orphan cr's to be migrated,so _cluster dir should not be created.
+		Expect(err).To(HaveOccurred())
+
+	})
+})

--- a/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
+++ b/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
@@ -60,11 +60,14 @@ var _ = Describe("Cluster-level export filtering", func() {
 		By("Running crane export, transform, apply")
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Verifying orphan ClusterRole Did not migrate")
-		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
-		_, _, err = utils.HasFilesRecursively(clusterDir)
-		//we dont expct orphan cr's to be migrated,so _cluster dir should not be created.
-		Expect(err).To(HaveOccurred())
+		By("Verifying no resources failed to export")
+		failuresDir := filepath.Join(paths.ExportDir, "failures", namespace)
+		hasFiles, _, err := utils.HasFilesRecursively(failuresDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hasFiles).To(BeFalse())
 
+		By("Verifying orphan ClusterRole Did not migrate")
+		//we don't expect orphan cr's to be migrated,so _cluster dir should not be created.
+		Expect(filepath.Join(paths.OutputDir, "resources", "_cluster")).NotTo(BeADirectory())
 	})
 })

--- a/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
+++ b/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var _ = Describe("Cluster-level export filtering", func() {
-	It("[CA-6] Should not export orphan ClusterRole with no CRB linking it to exported SAs", Label("tier1"), func() {
+	It("[MTA-867] Should not export orphan ClusterRole with no CRB linking it to exported SAs", Label("tier1"), func() {
 		appName := "simple-nginx-nopv"
 		namespace := "simple-nginx-nopv"
 		serviceName := "my-" + appName
@@ -60,7 +60,7 @@ var _ = Describe("Cluster-level export filtering", func() {
 		By("Running crane export, transform, apply")
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Verifying orphan ClusterRole Didnot migrate")
+		By("Verifying orphan ClusterRole Did not migrate")
 		clusterDir := filepath.Join(paths.OutputDir, "resources", "_cluster")
 		_, _, err = utils.HasFilesRecursively(clusterDir)
 		//we dont expct orphan cr's to be migrated,so _cluster dir should not be created.

--- a/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
+++ b/e2e-tests/tests/tier1/mta_867_orphan_clusterrole_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Cluster-level export filtering", func() {
 
 		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
-		applyOpts := ApplyOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir,
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir,
 			OutputDir: paths.OutputDir}
 
 		DeferCleanup(func() {


### PR DESCRIPTION
closes: #581
closes: #634 

## Summary

Add e2e test coverage for RBAC-related cluster-level export scenarios:

- **MTA-856 (tier1)**: Verifies that ClusterRole and multiple ClusterRoleBindings linked to ServiceAccounts in the exported namespace are correctly migrated
- **MTA-866 (tier0)**: Verifies that namespace-admin users can migrate namespace-only workloads without split apply, and no cluster resources are exported
- **MTA-867 (tier1)**: Verifies that orphan ClusterRoles (not linked via CRB to any exported ServiceAccount) are correctly filtered out and not migrated


## Verified
those test was tested both on Minikube and ocp

## Test plan

- [ ] Run tier0 tests: `ginkgo --label-filter="tier0" ./e2e-tests/...`
- [ ] Run tier1 tests: `ginkgo --label-filter="tier1" ./e2e-tests/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Tests**
  * Added an end-to-end tier0 test for namespace-admin migrations, confirming namespace-scoped workloads don’t produce cluster-level resources during migration.
  * Added an end-to-end tier1 test to validate cluster-level RBAC export/import across multiple ClusterRoleBindings and their ServiceAccount subjects.
  * Added an end-to-end tier1 test ensuring orphaned ClusterRoles are filtered out from migration output.
  * Expanded assertions to apply generated manifests to the target, scale the deployment, and confirm the app eventually validates successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->