### PR TITLE
:bug: fix-sanitize plugin manifest name in plugin-manager add to prevent p…

### DIFF
--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/konveyor/crane/internal/flags"
@@ -201,7 +202,23 @@ func (o *Options) run(args []string) error {
 	return nil
 }
 
+func validateFileInput(filepath, filename string) error {
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		return fmt.Errorf("invalid plugin name %q: must not contain path separators or traversal sequences", filename)
+	}
+
+	existingPath := filepath + "/" + filename
+	if _, err := os.Stat(existingPath); err == nil {
+		return fmt.Errorf("a plugin named %q already exists at %s, please remove it first before installing", filename, existingPath)
+	}
+	return nil
+}
+
 func downloadBinary(filepath string, filename string, url string, log *logrus.Logger) error {
+	if err := validateFileInput(filepath, filename); err != nil {
+		return err
+	}
+	
 	var binaryContents io.Reader
 	isUrl, url := plugin.IsUrl(url)
 	if !isUrl {

--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -202,14 +202,16 @@ func (o *Options) run(args []string) error {
 	return nil
 }
 
-func validateFileInput(filepath, filename string) error {
-	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
-		return fmt.Errorf("invalid plugin name %q: must not contain path separators or traversal sequences", filename)
+func validateFileInput(dir, filename string) error {
+	if filename == "" || filename == "." || filename == ".." || strings.ContainsRune(filename, '\\') || filename != filepath.Base(filename) {
+		return fmt.Errorf("invalid plugin name %q: must be a bare file name without path separators or traversal sequences", filename)
 	}
 
-	existingPath := filepath + "/" + filename
-	if _, err := os.Stat(existingPath); err == nil {
+	existingPath := filepath.Join(dir, filename)
+	if _, err := os.Lstat(existingPath); err == nil {
 		return fmt.Errorf("a plugin named %q already exists at %s, please remove it first before installing", filename, existingPath)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("failed to check destination %s: %w", existingPath, err)
 	}
 	return nil
 }
@@ -218,7 +220,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	if err := validateFileInput(filepath, filename); err != nil {
 		return err
 	}
-	
+
 	var binaryContents io.Reader
 	isUrl, url := plugin.IsUrl(url)
 	if !isUrl {
@@ -246,7 +248,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	}
 
 	// Create the file
-	pluginBinary, err := os.OpenFile(filepath+"/"+filename, syscall.O_RDWR|syscall.O_CREAT|syscall.O_TRUNC, 0777)
+	pluginBinary, err := os.OpenFile(filepath+"/"+filename, syscall.O_RDWR|syscall.O_CREAT|syscall.O_EXCL, 0755)
 	if err != nil {
 		return err
 	}

--- a/cmd/plugin-manager/add/add_test.go
+++ b/cmd/plugin-manager/add/add_test.go
@@ -1,0 +1,58 @@
+package add
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateFileInput(t *testing.T) {
+	dir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		filename string
+		wantErr  bool
+	}{
+		{name: "valid name", filename: "my-plugin", wantErr: false},
+		{name: "empty name", filename: "", wantErr: true},
+		{name: "dot", filename: ".", wantErr: true},
+		{name: "dotdot", filename: "..", wantErr: true},
+		{name: "forward slash", filename: "foo/bar", wantErr: true},
+		{name: "back slash", filename: "foo\\bar", wantErr: true},
+		{name: "traversal", filename: "../evil", wantErr: true},
+		{name: "absolute path", filename: "/etc/passwd", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateFileInput(dir, tt.filename); (err != nil) != tt.wantErr {
+				t.Errorf("validateFileInput(%q, %q) error = %v, wantErr %v", dir, tt.filename, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateFileInputExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	filename := "existing-plugin"
+	if err := os.WriteFile(filepath.Join(dir, filename), []byte("x"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateFileInput(dir, filename); err == nil {
+		t.Errorf("expected error for existing file, got nil")
+	}
+}
+
+func TestValidateFileInputExistingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	filename := "broken-link"
+	if err := os.Symlink(filepath.Join(dir, "does-not-exist"), filepath.Join(dir, filename)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateFileInput(dir, filename); err == nil {
+		t.Errorf("expected error for existing broken symlink, got nil")
+	}
+}


### PR DESCRIPTION
closes: #670 

## Summary

The `plugin-manager add` command uses the `name` field from the plugin manifest as the binary filename without any sanitization. This allows a malicious plugin repository to:

1. **Override existing plugins** — a manifest can set its `name` to an already-installed plugin (e.g. `OpenShiftPlugin`), silently replacing it with a trojanized version
2. **Write files anywhere on disk** — a manifest `name` containing `../../` sequences escapes the plugins directory, writing an executable (0777 permissions) to arbitrary paths

### Root Cause

In `downloadBinary()`, `value.Name` from the manifest YAML is passed directly to `os.OpenFile` as the filename with no validation.

### Fix

Added a `validateFileInput()` function that runs before any download:
- **Rejects** names containing `/`, `\`, or `..` — blocks path traversal
- **Rejects** names that match an already-installed plugin binary — blocks silent override

### PoC

Full end-to-end proof of concept: https://github.com/RanWurmbrand/compromised-plugins

## Test plan

- [ ] `crane plugin-manager add EvilPlugin` with a manifest name containing `../../` is rejected with an error
- [ ] `crane plugin-manager add CoolPlugin` with a manifest name matching an existing plugin (`OpenShiftPlugin`) is rejected with an error
- [ ] Normal plugin installation (manifest name matches requested name, no traversal) still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for plugin filenames to reject unsafe paths and prevent path traversal.
  * Prevented downloads from overwriting an existing plugin binary.
  * Invalid requests now fail before downloading or writing files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->