### PR TITLE
:test_tube: Fix mta 801 test failing on OCP

### DIFF
--- a/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_801_stateful_migration_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Stateful app migration", func() {
 		tgtApp := scenario.TgtApp
 		kubectlSrc := scenario.KubectlSrc
 		kubectlTgt := scenario.KubectlTgt
+		isOpenShift := kubectlSrc.IsOpenShift()
 
 		By("Prepare source app")
 		log.Printf("Preparing source app %s in namespace %s\n", srcApp.Name, srcApp.Namespace)
@@ -63,16 +64,20 @@ var _ = Describe("Stateful app migration", func() {
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 		log.Printf("Crane pipeline completed for namespace %s\n", srcApp.Namespace)
 		By("Compare YAML semantic diff of golden and actual export files")
-		goldenExportDir, err := utils.GoldenManifestsDir(appName, "export")
+		goldenExportDir, err := utils.GoldenManifestsDirForPlatform(appName, "export", isOpenShift)
 		Expect(err).NotTo(HaveOccurred())
-		if err := utils.CompareDirectoryYAMLSemanticsExport(goldenExportDir, paths.ExportDir); err != nil {
+		compareExport := utils.CompareDirectoryYAMLSemanticsExport
+		if isOpenShift {
+			compareExport = utils.CompareDirectoryYAMLSemanticsExportAllowOptionalOCPOutputDefaults
+		}
+		if err := compareExport(goldenExportDir, paths.ExportDir); err != nil {
 			Fail(fmt.Sprintf("YAML semantic diff of golden and actual export files: %v", err))
 		} else {
 			log.Printf("YAML semantic diff of golden and actual export files: no differences found")
 		}
 		log.Printf("Yaml diff comparison completed for export files successfully")
 		By("Compare YAML semantic diff of golden and actual output files")
-		goldenOutputDir, err := utils.GoldenManifestsDir(appName, "output")
+		goldenOutputDir, err := utils.GoldenManifestsDirForPlatform(appName, "output", isOpenShift)
 		Expect(err).NotTo(HaveOccurred())
 		if err := utils.CompareDirectoryYAMLSemantics(goldenOutputDir, paths.OutputDir); err != nil {
 			Fail(fmt.Sprintf("YAML semantic diff of golden and actual output files: %v", err))

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -334,12 +334,20 @@ func isOptionalOCPOutputIdentity(identity string) bool {
 			strings.HasSuffix(identity, "|system:image-builders") ||
 			strings.HasSuffix(identity, "|system:image-pullers")):
 		return true
+	case strings.HasPrefix(identity, "authorization.openshift.io/v1|RoleBinding|") &&
+		(strings.HasSuffix(identity, "|system:deployers") ||
+			strings.HasSuffix(identity, "|system:image-builders") ||
+			strings.HasSuffix(identity, "|system:image-pullers")):
+		return true
 	case strings.HasPrefix(identity, "v1|ServiceAccount|") &&
 		(strings.HasSuffix(identity, "|builder") ||
 			strings.HasSuffix(identity, "|deployer")):
 		return true
 	case strings.HasPrefix(identity, "v1|ConfigMap|") &&
 		strings.HasSuffix(identity, "|openshift-service-ca.crt"):
+		return true
+	case strings.HasPrefix(identity, "v1|Secret|") &&
+		strings.Contains(identity, "|dockercfg:"):
 		return true
 	default:
 		return false


### PR DESCRIPTION
Fixed mta 801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stateful migration validation across OpenShift and non-OpenShift platforms.
  * Updated manifest comparisons to use platform-specific expected outputs.
  * Enhanced export comparisons to correctly handle platform-generated resources and optional identities.
  * Reduced false differences for OpenShift role bindings, service accounts, config maps, and secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->