### PR TITLE
:bug: Fix transfer-pvc silently producing empty PVCs when rsync server is unhealthy

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -512,14 +512,19 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		return phases.Fail(err, "error creating rsync transfer server")
 	}
 
-	_ = wait.PollUntil(time.Second*5, func() (done bool, err error) {
-		ready, err := rsyncServer.IsHealthy(context.TODO(), destClient)
+	healthCtx, healthCancel := context.WithTimeout(context.TODO(), 5*time.Minute)
+	defer healthCancel()
+	err = wait.PollUntilContextCancel(healthCtx, time.Second*5, false, func(ctx context.Context) (done bool, err error) {
+		ready, err := rsyncServer.IsHealthy(ctx, destClient)
 		if err != nil {
 			fmt.Fprintf(t.ErrOut, "  rsync server not ready, retrying...\n")
 			return false, nil
 		}
 		return ready, nil
-	}, make(<-chan struct{}))
+	})
+	if err != nil {
+		log.Fatal(err, "rsync server failed to become healthy")
+	}
 	phases.End("ok", "")
 
 	// ---- Phase 6: Copying data (rsync) ----

--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -132,7 +132,9 @@ func VerifyPVCHasData(kubectl KubectlRunner, namespace, pvcName, mountPath strin
 		return fmt.Errorf("inspector pod %s/%s for PVC %s not ready: phase=%s", namespace, podName, pvcName, lastPhase)
 	}
 
-	out, err := kubectl.Run("exec", podName, "-n", namespace, "--", "find", mountPath, "-mindepth", "1", "-maxdepth", "1")
+	out, err := kubectl.Run("exec", podName, "-n", namespace, "--",
+		"find", mountPath, "-mindepth", "1", "-maxdepth", "1",
+		"!", "-name", "lost+found", "-print")
 	if err != nil {
 		return fmt.Errorf("exec into inspector pod for PVC %s: %w", pvcName, err)
 	}

--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -111,10 +111,14 @@ func VerifyPVCHasData(kubectl KubectlRunner, namespace, pvcName, mountPath strin
 		}
 	}()
 
+	var lastPhase string
+	var lastErr error
 	ready := false
 	for i := 0; i < 30; i++ {
 		out, err := kubectl.Run("get", "pod", podName, "-n", namespace,
 			"-o", "jsonpath={.status.phase}")
+		lastPhase = out
+		lastErr = err
 		if err == nil && out == "Running" {
 			ready = true
 			break
@@ -122,7 +126,10 @@ func VerifyPVCHasData(kubectl KubectlRunner, namespace, pvcName, mountPath strin
 		time.Sleep(2 * time.Second)
 	}
 	if !ready {
-		return fmt.Errorf("inspector pod for PVC %s did not become ready", pvcName)
+		if lastErr != nil {
+			return fmt.Errorf("inspector pod %s/%s for PVC %s not ready: %w", namespace, podName, pvcName, lastErr)
+		}
+		return fmt.Errorf("inspector pod %s/%s for PVC %s not ready: phase=%s", namespace, podName, pvcName, lastPhase)
 	}
 
 	out, err := kubectl.Run("exec", podName, "-n", namespace, "--", "find", mountPath, "-mindepth", "1", "-maxdepth", "1")

--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -3,10 +3,13 @@ package framework
 import (
 	"context"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"log"
 	"os"
 	"strings"
+	"time"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,6 +61,78 @@ func VerifyPVCsExistByName(sourcePVCs, targetPVCs []corev1.PersistentVolumeClaim
 	if len(missing) > 0 {
 		return fmt.Errorf("source PVCs not found in target: %v", missing)
 	}
+	return nil
+}
+
+// VerifyPVCHasData mounts a PVC in a temporary pod and checks that the mount
+// path is non-empty. Returns an error if empty, which typically indicates a
+// failed rsync transfer.
+func VerifyPVCHasData(kubectl KubectlRunner, namespace, pvcName, mountPath string) error {
+	podName := fmt.Sprintf("pvc-check-%s", pvcName)
+	podSpec := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Pod",
+		"metadata": map[string]any{
+			"name":      podName,
+			"namespace": namespace,
+		},
+		"spec": map[string]any{
+			"restartPolicy": "Never",
+			"containers": []map[string]any{{
+				"name":    "check",
+				"image":   "busybox",
+				"command": []string{"sleep", "60"},
+				"volumeMounts": []map[string]any{{
+					"name":      "data",
+					"mountPath": mountPath,
+				}},
+			}},
+			"volumes": []map[string]any{{
+				"name": "data",
+				"persistentVolumeClaim": map[string]any{
+					"claimName": pvcName,
+				},
+			}},
+		},
+	}
+
+	specJSON, err := json.Marshal(podSpec)
+	if err != nil {
+		return fmt.Errorf("marshal pod spec: %w", err)
+	}
+
+	_, err = kubectl.RunWithStdin(string(specJSON), "apply", "-f", "-")
+	if err != nil {
+		return fmt.Errorf("create inspector pod for PVC %s: %w", pvcName, err)
+	}
+	defer func() {
+		if _, delErr := kubectl.Run("delete", "pod", podName, "-n", namespace, "--ignore-not-found=true"); delErr != nil {
+			log.Printf("cleanup: failed to delete inspector pod %s: %v", podName, delErr)
+		}
+	}()
+
+	ready := false
+	for i := 0; i < 30; i++ {
+		out, err := kubectl.Run("get", "pod", podName, "-n", namespace,
+			"-o", "jsonpath={.status.phase}")
+		if err == nil && out == "Running" {
+			ready = true
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !ready {
+		return fmt.Errorf("inspector pod for PVC %s did not become ready", pvcName)
+	}
+
+	out, err := kubectl.Run("exec", podName, "-n", namespace, "--", "find", mountPath, "-mindepth", "1", "-maxdepth", "1")
+	if err != nil {
+		return fmt.Errorf("exec into inspector pod for PVC %s: %w", pvcName, err)
+	}
+	if strings.TrimSpace(out) == "" {
+		return fmt.Errorf("PVC %s/%s is empty at %s after transfer — rsync may have failed silently", namespace, pvcName, mountPath)
+	}
+	log.Printf("PVC %s/%s has data at %s: %d entries", namespace, pvcName, mountPath, len(strings.Split(strings.TrimSpace(out), "\n")))
 	return nil
 }
 

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -185,6 +185,15 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		Expect(VerifyPVCsExistByName(pvcs, tgtpvcs)).NotTo(HaveOccurred())
 		log.Printf("Found %d PVCs in target namespace %q", len(tgtpvcs), tgtApp.Namespace)
 
+		By("Verify transferred PVCs contain data")
+		for _, pvc := range tgtpvcs {
+			mountPath := "/var/lib/mysql"
+			if strings.Contains(pvc.Name, "data1") {
+				mountPath = "/test-data"
+			}
+			Expect(VerifyPVCHasData(kubectlTgtNonAdmin, tgtApp.Namespace, pvc.Name, mountPath)).NotTo(HaveOccurred())
+		}
+
 		By("Apply rendered manifests to target")
 		log.Printf("Applying rendered manifests on target namespace %s from %s\n", tgtApp.Namespace, paths.OutputDir)
 		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())


### PR DESCRIPTION
Fixes [743](https://github.com/migtools/crane/issues/743)

Before fix, the `transfer-pvc` command would launch the rsync client even if the rsync server was down, rsync would transfer nothing, and `transfer-pvc` would report success with exit code 0 — leaving the target PVC Bound but empty.

After fix, `transfer-pvc` polls rsync server health every 5 seconds and times out after 5 minutes with this message:
"rsync server failed to become healthy"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer reliability by enforcing a bounded rsync server readiness check and failing fast with a clear error if it does not become healthy in time.

* **Tests**
  * Added a post-transfer verification step that inspects transferred persistent volumes and fails the end-to-end run if the expected data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->