### PR TITLE
:book: Document StatefulSet StorageClass conversion known limitation

### DIFF
--- a/docs/CRANE_COMPATIBILITY_MATRIX.md
+++ b/docs/CRANE_COMPATIBILITY_MATRIX.md
@@ -43,7 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
-  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates` (immutable, and expecting the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name). Same-cluster conversions require a renamed destination PVC, so this path is **not yet supported** for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -75,6 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
-* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
+* [ ] **StatefulSet StorageClass Conversion:** Same-cluster StorageClass conversion is not yet supported for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). For cross-cluster or cross-namespace transfers that preserve the original PVC name, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---

--- a/docs/CRANE_COMPATIBILITY_MATRIX.md
+++ b/docs/CRANE_COMPATIBILITY_MATRIX.md
@@ -43,7 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
-  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates` (immutable, and expecting the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name). Same-cluster conversions require a renamed destination PVC, so this path is **not yet supported** for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -75,6 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
-* [ ] **StatefulSet StorageClass Conversion:** Same-cluster StorageClass conversion is not yet supported for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). For cross-cluster or cross-namespace transfers that preserve the original PVC name, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
+* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---

--- a/docs/CRANE_COMPATIBILITY_MATRIX.md
+++ b/docs/CRANE_COMPATIBILITY_MATRIX.md
@@ -43,6 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -74,5 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
+* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---

--- a/docs/commands/transfer-pvc.md
+++ b/docs/commands/transfer-pvc.md
@@ -73,7 +73,7 @@ crane transfer-pvc --source-context=mycluster --destination-context=mycluster \
   --dest-storage-class=gp3 --endpoint=route
 ```
 
-> **Warning — StorageClass conversion with StatefulSets:** `crane transfer-pvc` migrates data from existing PVCs to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. If the StatefulSet is scaled up after conversion without being recreated, new replicas will provision PVCs on the original StorageClass. To complete the conversion, delete the StatefulSet with `--cascade=orphan` (preserving existing pods and PVCs) and recreate it with the updated `storageClassName` in the `volumeClaimTemplates` spec.
+> **Warning — StatefulSet StorageClass conversion is not yet supported for same-cluster transfers:** `crane transfer-pvc` migrates data to a new PVC, but it does not update the StatefulSet's `volumeClaimTemplates`, which is immutable and expects the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name. Same-cluster transfers (like the example above) require a renamed destination PVC, so a recreated StatefulSet will not adopt it — scaling up instead provisions a new, empty PVC on the original StorageClass. This is tracked in [#659](https://github.com/migtools/crane/issues/659). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: delete the StatefulSet with `--cascade=orphan` (preserving existing pods and PVCs) and recreate it with the updated `storageClassName` in the `volumeClaimTemplates` spec to complete the conversion in that case.
 
 ### Endpoint Options
 

--- a/docs/commands/transfer-pvc.md
+++ b/docs/commands/transfer-pvc.md
@@ -73,7 +73,7 @@ crane transfer-pvc --source-context=mycluster --destination-context=mycluster \
   --dest-storage-class=gp3 --endpoint=route
 ```
 
-> **Warning — StatefulSet StorageClass conversion is not yet supported for same-cluster transfers:** `crane transfer-pvc` migrates data to a new PVC, but it does not update the StatefulSet's `volumeClaimTemplates`, which is immutable and expects the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name. Same-cluster transfers (like the example above) require a renamed destination PVC, so a recreated StatefulSet will not adopt it — scaling up instead provisions a new, empty PVC on the original StorageClass. This is tracked in [#659](https://github.com/migtools/crane/issues/659). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: delete the StatefulSet with `--cascade=orphan` (preserving existing pods and PVCs) and recreate it with the updated `storageClassName` in the `volumeClaimTemplates` spec to complete the conversion in that case.
+> **Warning — StorageClass conversion with StatefulSets:** `crane transfer-pvc` migrates data from existing PVCs to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. If the StatefulSet is scaled up after conversion without being recreated, new replicas will provision PVCs on the original StorageClass. To complete the conversion, delete the StatefulSet with `--cascade=orphan` (preserving existing pods and PVCs) and recreate it with the updated `storageClassName` in the `volumeClaimTemplates` spec.
 
 ### Endpoint Options
 

--- a/docs/commands/transfer-pvc.md
+++ b/docs/commands/transfer-pvc.md
@@ -73,6 +73,8 @@ crane transfer-pvc --source-context=mycluster --destination-context=mycluster \
   --dest-storage-class=gp3 --endpoint=route
 ```
 
+> **Warning — StorageClass conversion with StatefulSets:** `crane transfer-pvc` migrates data from existing PVCs to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. If the StatefulSet is scaled up after conversion without being recreated, new replicas will provision PVCs on the original StorageClass. To complete the conversion, delete the StatefulSet with `--cascade=orphan` (preserving existing pods and PVCs) and recreate it with the updated `storageClassName` in the `volumeClaimTemplates` spec.
+
 ### Endpoint Options
 
 Endpoint enables a connection between the source and destination cluster for data transfer. It is created in the destination cluster. The destination cluster must support the kind of endpoint used.

--- a/docs/resource-compatibility.md
+++ b/docs/resource-compatibility.md
@@ -43,7 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
-  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates` (immutable, and expecting the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name). Same-cluster conversions require a renamed destination PVC, so this path is **not yet supported** for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -75,6 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
-* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
+* [ ] **StatefulSet StorageClass Conversion:** Same-cluster StorageClass conversion is not yet supported for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). For cross-cluster or cross-namespace transfers that preserve the original PVC name, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---

--- a/docs/resource-compatibility.md
+++ b/docs/resource-compatibility.md
@@ -43,7 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
-  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates` (immutable, and expecting the destination PVC to keep the deterministic `<template>-<statefulset>-<ordinal>` name). Same-cluster conversions require a renamed destination PVC, so this path is **not yet supported** for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). Cross-cluster or cross-namespace transfers that preserve the original PVC name are unaffected: recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -75,6 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
-* [ ] **StatefulSet StorageClass Conversion:** Same-cluster StorageClass conversion is not yet supported for StatefulSet-managed PVCs (tracked in [#659](https://github.com/migtools/crane/issues/659)). For cross-cluster or cross-namespace transfers that preserve the original PVC name, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
+* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---

--- a/docs/resource-compatibility.md
+++ b/docs/resource-compatibility.md
@@ -43,6 +43,7 @@ These resources are the core of any migration and are moved automatically.
   > **Warning — Namespace renaming:** If the namespace is renamed during migration, NetworkPolicy `namespaceSelector` entries that match the old namespace by label (e.g., `kubernetes.io/metadata.name: old-ns`) are not updated automatically. Manually update them before applying.
 * **Config & Secrets:** ConfigMap, Secret, ServiceAccount.
 * **Storage:** PersistentVolumeClaim (PVC).
+  > **Warning — StorageClass conversion:** `crane transfer-pvc` migrates data to new PVCs on the target StorageClass, but it does not modify the StatefulSet's `volumeClaimTemplates`. Scaling up a StatefulSet after conversion (without recreating it) provisions new replicas on the original StorageClass. Recreate the StatefulSet with `--cascade=orphan` and the updated `storageClassName` to complete the conversion.
 
 ### 3.2 Cluster-Scoped Resources (Conditionally Supported)
 These resources are migrated **only if they are linked to the namespace workload** and the execution context has appropriate permissions.
@@ -74,5 +75,6 @@ For "Conditionally Supported" resources to migrate successfully, the following m
 * [ ] **Operator Readiness:** All required Operators are installed via OperatorHub on the target cluster.
 * [ ] **CRD Check:** Verify if any global CRDs need to be manually applied to the target to avoid "orphan" resources.
 * [ ] **Namespace Renaming:** If renaming the namespace, manually update any ClusterRoleBinding subjects and NetworkPolicy namespaceSelector entries matching the old namespace by label before applying.
+* [ ] **StatefulSet StorageClass Conversion:** If converting a StatefulSet's PVCs to a new StorageClass, recreate the StatefulSet (`--cascade=orphan`) with the updated `storageClassName` in `volumeClaimTemplates` before scaling up.
 
 ---


### PR DESCRIPTION
Documents a known limitation: `crane transfer-pvc` migrates PVC data to a new StorageClass but does not update the StatefulSet's `volumeClaimTemplates`. Scaling up after conversion without recreating the StatefulSet provisions new replicas on the original StorageClass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warnings that PVC migration does not update StatefulSet storage templates.
  * Documented the required procedure to recreate StatefulSets with the destination StorageClass before scaling.
  * Updated pre-migration checklists with this requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->