### PR TITLE
:sparkles: added encryption support for indirect migration

### DIFF
--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -370,7 +370,7 @@ func generateCryptSection(cloudStoragePath string) (string, error) {
 		return "", fmt.Errorf("failed to obscure encryption password: %w", err)
 	}
 
-	return indirect.BuildCryptSection(cloudStoragePath, obscured), nil
+	return indirect.BuildCryptSection(cloudStoragePath, obscured)
 }
 
 // rcloneObscure encodes a plaintext password in rclone's obscured format.

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -2,7 +2,12 @@ package transfer_pvc
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -71,13 +76,27 @@ func (t *TransferPVCCommand) runIndirect() error {
 	// Resolve rclone config secret name
 	configSecret := t.Flags.RcloneConfigSecret
 	if t.Flags.RcloneConfigFile != "" {
-		secretName, err := t.createTempRcloneSecret(srcClient, t.PVC.Namespace.source, t.Flags.RcloneConfigFile, t.PVC.Name.source)
+		configData, err := os.ReadFile(t.Flags.RcloneConfigFile)
+		if err != nil {
+			return fmt.Errorf("failed to read rclone config file %s: %w", t.Flags.RcloneConfigFile, err)
+		}
+
+		if t.Flags.Encrypt {
+			remotePath := fmt.Sprintf("%s/%s/%s", t.Flags.CloudStorage, t.PVC.Namespace.source, t.PVC.Name.source)
+			cryptSection, err := generateCryptSection(remotePath)
+			if err != nil {
+				return fmt.Errorf("failed to generate encryption config: %w", err)
+			}
+			configData = append(configData, []byte(cryptSection)...)
+		}
+
+		secretName, err := t.createTempRcloneSecretFromData(srcClient, t.PVC.Namespace.source, configData, t.PVC.Name.source)
 		if err != nil {
 			return fmt.Errorf("failed to create rclone config secret on source: %w", err)
 		}
 		configSecret = secretName
 
-		_, err = t.createTempRcloneSecret(destClient, t.PVC.Namespace.destination, t.Flags.RcloneConfigFile, t.PVC.Name.destination)
+		_, err = t.createTempRcloneSecretFromData(destClient, t.PVC.Namespace.destination, configData, t.PVC.Name.destination)
 		if err != nil {
 			return fmt.Errorf("failed to create rclone config secret on destination: %w", err)
 		}
@@ -301,15 +320,7 @@ func checkRclonePartialSuccess(output, podName, namespace string) error {
 	return fmt.Errorf("pod %s/%s failed", namespace, podName)
 }
 
-func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, configFilePath, labelPVCName string) (string, error) {
-	data, err := os.ReadFile(configFilePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to read rclone config file %s: %w", configFilePath, err)
-	}
-
-	// Secret name uses source PVC name so both clusters use the same name
-	// (crane-lib references a single ConfigSecret for upload and download).
-	// Label uses the per-cluster PVC name so Cleanup can find it by label selector.
+func (t *TransferPVCCommand) createTempRcloneSecretFromData(c client.Client, namespace string, configData []byte, labelPVCName string) (string, error) {
 	secretName := fmt.Sprintf("crane-rclone-config-%s", getValidatedResourceName(t.PVC.Name.source))
 
 	secret := &corev1.Secret{
@@ -324,11 +335,11 @@ func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, 
 			},
 		},
 		Data: map[string][]byte{
-			"rclone.conf": data,
+			"rclone.conf": configData,
 		},
 	}
 
-	err = c.Create(context.TODO(), secret)
+	err := c.Create(context.TODO(), secret)
 	if errors.IsAlreadyExists(err) {
 		existing := &corev1.Secret{}
 		if getErr := c.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: namespace}, existing); getErr != nil {
@@ -343,4 +354,44 @@ func (t *TransferPVCCommand) createTempRcloneSecret(c client.Client, namespace, 
 	}
 
 	return secretName, nil
+}
+
+// generateCryptSection creates the [encrypted] crypt overlay section for rclone.conf
+// with an auto-generated password. The password is random per transfer — encryption
+// is for data-in-transit in the bucket, not long-term storage.
+func generateCryptSection(cloudStoragePath string) (string, error) {
+	password := make([]byte, 32)
+	if _, err := io.ReadFull(rand.Reader, password); err != nil {
+		return "", fmt.Errorf("failed to generate encryption password: %w", err)
+	}
+
+	obscured, err := rcloneObscure(base64.RawURLEncoding.EncodeToString(password))
+	if err != nil {
+		return "", fmt.Errorf("failed to obscure encryption password: %w", err)
+	}
+
+	return indirect.BuildCryptSection(cloudStoragePath, obscured), nil
+}
+
+// rcloneObscure encodes a plaintext password in rclone's obscured format.
+// This is AES-CTR with rclone's well-known key, identical to "rclone obscure".
+func rcloneObscure(plaintext string) (string, error) {
+	key := []byte{
+		0x9c, 0x93, 0x5b, 0x48, 0x73, 0x0a, 0x55, 0x4d,
+		0x6b, 0xfd, 0x7c, 0x63, 0xc8, 0x86, 0xa9, 0x2b,
+		0xd3, 0x90, 0x19, 0x8e, 0xb8, 0x12, 0x8a, 0xfb,
+		0xf4, 0xde, 0x16, 0x2b, 0x8b, 0x95, 0xf6, 0x38,
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return "", err
+	}
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], []byte(plaintext))
+	return base64.RawURLEncoding.EncodeToString(ciphertext), nil
 }

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -82,6 +82,9 @@ func (t *TransferPVCCommand) runIndirect() error {
 		}
 
 		if t.Flags.Encrypt {
+			if strings.Contains(string(configData), "[encrypted]") {
+				return fmt.Errorf("rclone config already contains an [encrypted] section; remove it or omit --encrypt")
+			}
 			remotePath := fmt.Sprintf("%s/%s/%s", t.Flags.CloudStorage, t.PVC.Namespace.source, t.PVC.Name.source)
 			cryptSection, err := generateCryptSection(remotePath)
 			if err != nil {

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -87,6 +87,7 @@ func (t *TransferPVCCommand) runIndirect() error {
 			if err != nil {
 				return fmt.Errorf("failed to generate encryption config: %w", err)
 			}
+			configData = append(configData, '\n')
 			configData = append(configData, []byte(cryptSection)...)
 		}
 

--- a/cmd/transfer-pvc/indirect_test.go
+++ b/cmd/transfer-pvc/indirect_test.go
@@ -1,0 +1,131 @@
+package transfer_pvc
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestRcloneObscure(t *testing.T) {
+	original := "test-encryption-password-42"
+	obscured, err := rcloneObscure(original)
+	if err != nil {
+		t.Fatalf("rcloneObscure() error: %v", err)
+	}
+	if obscured == "" {
+		t.Fatal("rcloneObscure() returned empty string")
+	}
+	if obscured == original {
+		t.Error("obscured value should differ from original")
+	}
+
+	// Round-trip: reveal the obscured value using the same algorithm
+	revealed, err := rcloneReveal(obscured)
+	if err != nil {
+		t.Fatalf("rcloneReveal() error: %v", err)
+	}
+	if revealed != original {
+		t.Errorf("round-trip failed: got %q, want %q", revealed, original)
+	}
+}
+
+func TestRcloneObscure_DifferentOutputEachCall(t *testing.T) {
+	a, _ := rcloneObscure("same-input")
+	b, _ := rcloneObscure("same-input")
+	if a == b {
+		t.Error("two calls with same input should produce different output (random IV)")
+	}
+}
+
+func TestGenerateCryptSection(t *testing.T) {
+	section, err := generateCryptSection("remote:my-bucket/ns/pvc")
+	if err != nil {
+		t.Fatalf("generateCryptSection() error: %v", err)
+	}
+
+	for _, want := range []string{"[encrypted]", "type = crypt", "remote = remote:my-bucket/ns/pvc", "password = "} {
+		if !strings.Contains(section, want) {
+			t.Errorf("output missing %q, got:\n%s", want, section)
+		}
+	}
+
+	// Verify the password field is non-empty
+	for _, line := range strings.Split(section, "\n") {
+		if strings.HasPrefix(line, "password = ") {
+			pw := strings.TrimPrefix(line, "password = ")
+			if pw == "" {
+				t.Error("password should not be empty")
+			}
+		}
+	}
+}
+
+func TestCheckRclonePartialSuccess(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		wantErr bool
+	}{
+		{
+			name:    "no stats in output",
+			output:  "some random log output\nERROR: something broke\n",
+			wantErr: true,
+		},
+		{
+			name:    "zero files transferred",
+			output:  "ERROR : permission denied\nTransferred:            0 / 5, 0%\n",
+			wantErr: true,
+		},
+		{
+			name: "permission error only — partial success",
+			output: "ERROR : .mongodb: failed to open directory \".mongodb\": open /data/.mongodb: permission denied\n" +
+				"Transferred:           22 / 22, 100%\n",
+			wantErr: false,
+		},
+		{
+			name:    "all files transferred no errors — should not reach this func but handle gracefully",
+			output:  "Transferred:           10 / 10, 100%\n",
+			wantErr: true, // no ERROR but pod failed — genuine failure
+		},
+		{
+			name: "non-permission error",
+			output: "ERROR : network timeout\n" +
+				"Transferred:            5 / 10, 50%\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkRclonePartialSuccess(tt.output, "test-pod", "test-ns")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkRclonePartialSuccess() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// rcloneReveal decodes an rclone-obscured value for testing round-trips.
+func rcloneReveal(obscured string) (string, error) {
+	key := []byte{
+		0x9c, 0x93, 0x5b, 0x48, 0x73, 0x0a, 0x55, 0x4d,
+		0x6b, 0xfd, 0x7c, 0x63, 0xc8, 0x86, 0xa9, 0x2b,
+		0xd3, 0x90, 0x19, 0x8e, 0xb8, 0x12, 0x8a, 0xfb,
+		0xf4, 0xde, 0x16, 0x2b, 0x8b, 0x95, 0xf6, 0x38,
+	}
+	ciphertext, err := base64.RawURLEncoding.DecodeString(obscured)
+	if err != nil {
+		return "", err
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+	buf := ciphertext[aes.BlockSize:]
+	iv := ciphertext[:aes.BlockSize]
+	stream := cipher.NewCTR(block, iv)
+	stream.XORKeyStream(buf, buf)
+	return string(buf), nil
+}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -258,6 +258,9 @@ func (t *TransferPVCCommand) Validate() error {
 		if t.Flags.RcloneConfigSecret != "" && t.Flags.RcloneConfigFile != "" {
 			return fmt.Errorf("--rclone-config-secret and --rclone-config-file are mutually exclusive")
 		}
+		if t.Flags.Encrypt && t.Flags.RcloneConfigSecret != "" {
+			return fmt.Errorf("--encrypt requires --rclone-config-file; it cannot be used with --rclone-config-secret")
+		}
 		return nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee
+	github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1
 	github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee h1:T3i160U9L0PjkleTXOFpoyAS/npIc8oG9XBlEjE/Uo8=
 github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1 h1:TfmdlBmsUSisxVDIREk0SrV+xAi7fmp27Yn+609cCFU=
+github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
 ## Summary

  Wire up the `--encrypt` flag for indirect PVC transfers. When set, crane auto-generates an encryption password, appends an rclone crypt overlay section to the rclone config, and creates the Secret with encryption enabled on both clusters.

  ### Changes

  - **`cmd/transfer-pvc/indirect.go`**
    - **`runIndirect()`** — When `--encrypt` is set, reads the rclone config file, generates a crypt section with an auto-generated password, appends it to the config data, then creates the Secret on both clusters with
  the combined config. Without `--encrypt`, behavior is unchanged.
    - **`createTempRcloneSecret` → `createTempRcloneSecretFromData`** — Renamed. Accepts `[]byte` config data instead of a file path. File reading moved to the caller so the config can be modified (crypt section
  appended) before creating the Secret.
    - **`generateCryptSection()`** — Generates a random 32-byte password, obscures it in rclone's format, and builds the `[encrypted]` crypt overlay config section pointing at the S3 path.
    - **`rcloneObscure()`** — Implements rclone's password obscuring format (AES-CTR with rclone's well-known key). Same algorithm as `rclone obscure` command, no rclone dependency needed.

  ### How it works

  When `--encrypt` is passed:

  1. Crane reads the user's rclone.conf
  2. Generates a random 32-byte encryption password
  3. Obscures it in rclone's format (AES-CTR + base64url)
  4. Appends an `[encrypted]` crypt overlay section to the config
  5. Creates the same Secret on both clusters (same password for encrypt + decrypt)
  6. crane-lib uses `encrypted:` as the remote path instead of the direct S3 path

  The resulting rclone.conf in the Secret:

  ```ini
  [remote]
  type = s3
  ...user's config...

  [encrypted]
  type = crypt
  remote = remote:bucket/ns/pvc
  password = <auto-generated-obscured>
```
  The password is random per transfer & ephemeral, not stored anywhere. After download and cleanup, the encrypted data on S3 is deleted.

  Tested locally

  - With --encrypt: file names and content encrypted on S3, data intact on target after decrypt (checksums match)
  - Without --encrypt: behavior identical to before, plaintext on S3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional AES encryption for indirect transfers.
  * Automatically generates and securely obscures encryption passwords.
  * Includes encryption settings when creating transfer secrets.

* **Improvements**
  * Streamlined configuration handling for transfer setup.
  * Updated the underlying transfer library.
  * Added validation to require a local configuration file when encryption is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->