### PR TITLE
:bug: transfer-pvc: Indirect mode flags silently ignored without --cloud-storage flags

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -254,7 +254,28 @@ func (t *TransferPVCCommand) Validate() error {
 		return err
 	}
 
-	if t.Flags.CloudStorage != "" {
+	cloudStorage := strings.TrimSpace(t.Flags.CloudStorage)
+
+	if t.Flags.CloudStorage != "" && cloudStorage == "" {
+		return fmt.Errorf("--cloud-storage value cannot be empty or whitespace")
+	}
+
+	indirectOnlyFlags := []struct {
+		set  bool
+		name string
+	}{
+		{t.Flags.Encrypt, "--encrypt"},
+		{t.Flags.KeepCloudData, "--keep-cloud-data"},
+		{t.Flags.RcloneConfigSecret != "", "--rclone-config-secret"},
+		{t.Flags.RcloneConfigFile != "", "--rclone-config-file"},
+	}
+	for _, f := range indirectOnlyFlags {
+		if f.set && cloudStorage == "" {
+			return fmt.Errorf("%s requires --cloud-storage", f.name)
+		}
+	}
+
+	if cloudStorage != "" {
 		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
 			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")
 		}
@@ -276,7 +297,7 @@ func (t *TransferPVCCommand) Validate() error {
 }
 
 func (t *TransferPVCCommand) Run() error {
-	if t.Flags.CloudStorage != "" {
+	if strings.TrimSpace(t.Flags.CloudStorage) != "" {
 		return t.runIndirect()
 	}
 	return t.run()

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -254,9 +254,9 @@ func (t *TransferPVCCommand) Validate() error {
 		return err
 	}
 
-	cloudStorage := strings.TrimSpace(t.Flags.CloudStorage)
+	cloudStorage := strings.TrimSpace(t.CloudStorage)
 
-	if t.Flags.CloudStorage != "" && cloudStorage == "" {
+	if t.CloudStorage != "" && cloudStorage == "" {
 		return fmt.Errorf("--cloud-storage value cannot be empty or whitespace")
 	}
 
@@ -264,10 +264,10 @@ func (t *TransferPVCCommand) Validate() error {
 		set  bool
 		name string
 	}{
-		{t.Flags.Encrypt, "--encrypt"},
-		{t.Flags.KeepCloudData, "--keep-cloud-data"},
-		{t.Flags.RcloneConfigSecret != "", "--rclone-config-secret"},
-		{t.Flags.RcloneConfigFile != "", "--rclone-config-file"},
+		{t.Encrypt, "--encrypt"},
+		{t.KeepCloudData, "--keep-cloud-data"},
+		{t.RcloneConfigSecret != "", "--rclone-config-secret"},
+		{t.RcloneConfigFile != "", "--rclone-config-file"},
 	}
 	for _, f := range indirectOnlyFlags {
 		if f.set && cloudStorage == "" {
@@ -276,13 +276,13 @@ func (t *TransferPVCCommand) Validate() error {
 	}
 
 	if cloudStorage != "" {
-		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
+		if t.RcloneConfigSecret == "" && t.RcloneConfigFile == "" {
 			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")
 		}
-		if t.Flags.RcloneConfigSecret != "" && t.Flags.RcloneConfigFile != "" {
+		if t.RcloneConfigSecret != "" && t.RcloneConfigFile != "" {
 			return fmt.Errorf("--rclone-config-secret and --rclone-config-file are mutually exclusive")
 		}
-		if t.Flags.Encrypt && t.Flags.RcloneConfigSecret != "" {
+		if t.Encrypt && t.RcloneConfigSecret != "" {
 			return fmt.Errorf("--encrypt requires --rclone-config-file; it cannot be used with --rclone-config-secret")
 		}
 		return nil
@@ -297,7 +297,7 @@ func (t *TransferPVCCommand) Validate() error {
 }
 
 func (t *TransferPVCCommand) Run() error {
-	if strings.TrimSpace(t.Flags.CloudStorage) != "" {
+	if strings.TrimSpace(t.CloudStorage) != "" {
 		return t.runIndirect()
 	}
 	return t.run()

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -230,13 +230,30 @@ func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
 		t.PVC.Namespace.destination = t.destinationContext.Namespace
 	}
 
+	if t.CloudStorage != "" && strings.TrimSpace(t.CloudStorage) == "" {
+		return fmt.Errorf("--cloud-storage value cannot be empty or whitespace")
+	}
+	t.CloudStorage = strings.TrimSpace(t.CloudStorage)
+
 	return nil
 }
 
 func (t *TransferPVCCommand) Validate() error {
-	if t.Flags.KeepCloudData && t.Flags.CloudStorage == "" {
+	cloudStorage := t.CloudStorage
+
+	if t.Encrypt && cloudStorage == "" {
+		return fmt.Errorf("--encrypt requires --cloud-storage")
+	}
+	if t.KeepCloudData && cloudStorage == "" {
 		return fmt.Errorf("--keep-cloud-data requires --cloud-storage")
 	}
+	if t.RcloneConfigSecret != "" && cloudStorage == "" {
+		return fmt.Errorf("--rclone-config-secret requires --cloud-storage")
+	}
+	if t.RcloneConfigFile != "" && cloudStorage == "" {
+		return fmt.Errorf("--rclone-config-file requires --cloud-storage")
+	}
+
 	if t.sourceContext == nil {
 		return fmt.Errorf("cannot evaluate source context")
 	}
@@ -252,28 +269,6 @@ func (t *TransferPVCCommand) Validate() error {
 	err := t.PVC.Validate()
 	if err != nil {
 		return err
-	}
-
-	cloudStorage := strings.TrimSpace(t.CloudStorage)
-
-	if t.CloudStorage != "" && cloudStorage == "" {
-		return fmt.Errorf("--cloud-storage value cannot be empty or whitespace")
-	}
-	t.CloudStorage = cloudStorage
-
-	indirectOnlyFlags := []struct {
-		set  bool
-		name string
-	}{
-		{t.Encrypt, "--encrypt"},
-		{t.KeepCloudData, "--keep-cloud-data"},
-		{t.RcloneConfigSecret != "", "--rclone-config-secret"},
-		{t.RcloneConfigFile != "", "--rclone-config-file"},
-	}
-	for _, f := range indirectOnlyFlags {
-		if f.set && cloudStorage == "" {
-			return fmt.Errorf("%s requires --cloud-storage", f.name)
-		}
 	}
 
 	if cloudStorage != "" {
@@ -298,7 +293,7 @@ func (t *TransferPVCCommand) Validate() error {
 }
 
 func (t *TransferPVCCommand) Run() error {
-	if strings.TrimSpace(t.CloudStorage) != "" {
+	if t.CloudStorage != "" {
 		return t.runIndirect()
 	}
 	return t.run()

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -259,6 +259,7 @@ func (t *TransferPVCCommand) Validate() error {
 	if t.CloudStorage != "" && cloudStorage == "" {
 		return fmt.Errorf("--cloud-storage value cannot be empty or whitespace")
 	}
+	t.CloudStorage = cloudStorage
 
 	indirectOnlyFlags := []struct {
 		set  bool

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -3,12 +3,10 @@ package transfer_pvc
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 	"testing"
 
-	"github.com/spf13/cobra"
 	rsynctransfer "github.com/migtools/pvc-transfer/transfer/rsync"
 	"github.com/migtools/pvc-transfer/transport"
 	appsv1 "k8s.io/api/apps/v1"
@@ -16,8 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1242,110 +1238,6 @@ func TestStripServerManagedPVCAnnotations(t *testing.T) {
 				if got[k] != v {
 					t.Errorf("key %q: got %q, want %q", k, got[k], v)
 				}
-			}
-		})
-	}
-}
-
-// newMinimalConfigFlags creates a ConfigFlags backed by an empty temp kubeconfig,
-// suitable for unit tests that call Complete() without a real cluster.
-func newMinimalConfigFlags(t *testing.T) *genericclioptions.ConfigFlags {
-	t.Helper()
-	cfg := clientcmdapi.NewConfig()
-	data, err := clientcmd.Write(*cfg)
-	if err != nil {
-		t.Fatalf("failed to serialise empty kubeconfig: %v", err)
-	}
-	f, err := os.CreateTemp("", "test-kubeconfig-*.yaml")
-	if err != nil {
-		t.Fatalf("failed to create temp kubeconfig: %v", err)
-	}
-	if _, err := f.Write(data); err != nil {
-		t.Fatalf("failed to write temp kubeconfig: %v", err)
-	}
-	f.Close()
-	t.Cleanup(func() { os.Remove(f.Name()) })
-
-	flags := genericclioptions.NewConfigFlags(false)
-	name := f.Name()
-	flags.KubeConfig = &name
-	return flags
-}
-
-// covers the whitespace-trimming and whitespace-rejection logic added to Complete() in PR #859.
-func TestComplete_CloudStorageWhitespace(t *testing.T) {
-	tests := []struct {
-		name         string
-		cloudStorage string
-		wantErr      bool
-		wantErrMsg   string
-		wantValue    string
-	}{
-		{
-			name:         "whitespace-only value is rejected",
-			cloudStorage: "   ",
-			wantErr:      true,
-			wantErrMsg:   "whitespace",
-		},
-		{
-			name:         "tab-only value is rejected",
-			cloudStorage: "\t",
-			wantErr:      true,
-			wantErrMsg:   "whitespace",
-		},
-		{
-			name:         "newline-only value is rejected",
-			cloudStorage: "\n",
-			wantErr:      true,
-			wantErrMsg:   "whitespace",
-		},
-		{
-			name:         "leading and trailing spaces are trimmed",
-			cloudStorage: "  remote:my-bucket  ",
-			wantErr:      false,
-			wantValue:    "remote:my-bucket",
-		},
-		{
-			name:         "leading whitespace only is trimmed",
-			cloudStorage: "\tremote:my-bucket",
-			wantErr:      false,
-			wantValue:    "remote:my-bucket",
-		},
-		{
-			name:         "valid value passes through unchanged",
-			cloudStorage: "remote:my-bucket",
-			wantErr:      false,
-			wantValue:    "remote:my-bucket",
-		},
-		{
-			name:         "empty value is accepted and stays empty",
-			cloudStorage: "",
-			wantErr:      false,
-			wantValue:    "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd := &cobra.Command{}
-			tc := &TransferPVCCommand{
-				configFlags: newMinimalConfigFlags(t),
-				Flags:       Flags{CloudStorage: tt.cloudStorage},
-			}
-			err := tc.Complete(cmd, nil)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("Complete() expected error but got nil")
-				}
-				if tt.wantErrMsg != "" && !strings.Contains(err.Error(), tt.wantErrMsg) {
-					t.Errorf("Complete() error = %q, want to contain %q", err.Error(), tt.wantErrMsg)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("Complete() unexpected error: %v", err)
-			}
-			if tc.CloudStorage != tt.wantValue {
-				t.Errorf("CloudStorage after Complete() = %q, want %q", tc.CloudStorage, tt.wantValue)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes [855](https://github.com/migtools/crane/issues/855) and [858](https://github.com/migtools/crane/issues/858)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud storage validation by ignoring leading and trailing whitespace.
  * Rejected values containing only whitespace.
  * Enforced required cloud storage settings for indirect transfer options.
  * Treated whitespace-only cloud storage entries as unset during transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->