### PR TITLE
:sparkles: feat(audit): improve logging in transfer-pvc command

### DIFF
--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -8,8 +8,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"log"
 	"os"
+
+	"github.com/sirupsen/logrus"
 	"strings"
 	"time"
 
@@ -25,6 +26,9 @@ import (
 )
 
 func (t *TransferPVCCommand) runIndirect() error {
+	log := t.globalFlags.GetLoggerOrDefault()
+	log.Infof("Starting indirect PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
+
 	fmt.Fprintf(os.Stderr, "\ncrane transfer-pvc (indirect via cloud storage)\n")
 	fmt.Fprintf(os.Stderr, "source context:      %s\n", t.Flags.SourceContext)
 	fmt.Fprintf(os.Stderr, "destination context: %s\n", t.Flags.DestinationContext)
@@ -36,19 +40,23 @@ func (t *TransferPVCCommand) runIndirect() error {
 
 	srcClient, err := t.getClientFromContext(t.Flags.SourceContext)
 	if err != nil {
+		log.Debugf("Unable to get source client: %v", err)
 		return fmt.Errorf("unable to get source client: %w", err)
 	}
 	destClient, err := t.getClientFromContext(t.Flags.DestinationContext)
 	if err != nil {
+		log.Debugf("Unable to get destination client: %v", err)
 		return fmt.Errorf("unable to get destination client: %w", err)
 	}
 
 	srcCfg, err := t.getRestConfigFromContext(t.Flags.SourceContext)
 	if err != nil {
+		log.Debugf("Unable to get source rest config: %v", err)
 		return fmt.Errorf("unable to get source rest config: %w", err)
 	}
 	destCfg, err := t.getRestConfigFromContext(t.Flags.DestinationContext)
 	if err != nil {
+		log.Debugf("Unable to get destination rest config: %v", err)
 		return fmt.Errorf("unable to get destination rest config: %w", err)
 	}
 
@@ -60,6 +68,7 @@ func (t *TransferPVCCommand) runIndirect() error {
 		Name:      t.PVC.Name.source,
 	}, srcPVC)
 	if err != nil {
+		log.Debugf("Unable to get source PVC %s/%s: %v", t.PVC.Namespace.source, t.PVC.Name.source, err)
 		return fmt.Errorf("unable to get source PVC: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[1/6] Reading source PVC ... ok\n")
@@ -69,6 +78,7 @@ func (t *TransferPVCCommand) runIndirect() error {
 	destPVC := t.buildDestinationPVC(srcPVC)
 	err = destClient.Create(context.TODO(), destPVC, &client.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
+		log.Debugf("Unable to create destination PVC %s/%s: %v", t.PVC.Namespace.destination, t.PVC.Name.destination, err)
 		return fmt.Errorf("unable to create destination PVC: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[2/6] Creating destination PVC ... ok\n")
@@ -78,15 +88,17 @@ func (t *TransferPVCCommand) runIndirect() error {
 	if t.Flags.RcloneConfigFile != "" {
 		configData, err := os.ReadFile(t.Flags.RcloneConfigFile)
 		if err != nil {
+			log.Debugf("Failed to read rclone config file: %v", err)
 			return fmt.Errorf("failed to read rclone config file %s: %w", t.Flags.RcloneConfigFile, err)
 		}
 
 		if t.Flags.Encrypt {
 			if strings.Contains(string(configData), "[encrypted]") {
+				log.Debugf("Rclone config already contains an [encrypted] section")
 				return fmt.Errorf("rclone config already contains an [encrypted] section; remove it or omit --encrypt")
 			}
 			remotePath := fmt.Sprintf("%s/%s/%s", t.Flags.CloudStorage, t.PVC.Namespace.source, t.PVC.Name.source)
-			cryptSection, err := generateCryptSection(remotePath)
+			cryptSection, err := generateCryptSection(remotePath, log)
 			if err != nil {
 				return fmt.Errorf("failed to generate encryption config: %w", err)
 			}
@@ -109,13 +121,13 @@ func (t *TransferPVCCommand) runIndirect() error {
 	// Get security contexts for source and target separately
 	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
-		log.Printf("WARN: could not determine source security context: %v", err)
+		log.Warnf("Could not determine source security context: %v", err)
 		uploadSecCtx = &corev1.PodSecurityContext{}
 	}
 
 	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
 	if err != nil {
-		log.Printf("WARN: could not determine target security context: %v", err)
+		log.Warnf("Could not determine target security context: %v", err)
 		downloadSecCtx = &corev1.PodSecurityContext{}
 	}
 	if downloadSecCtx.RunAsUser == nil && uploadSecCtx.RunAsUser != nil {
@@ -140,10 +152,10 @@ func (t *TransferPVCCommand) runIndirect() error {
 	defer func() {
 		fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ...\n")
 		if err := transfer.Cleanup(context.TODO(), srcClient, srcPVC.Namespace, srcPVC.Name); err != nil {
-			log.Printf("WARN: source cleanup: %v", err)
+			log.Warnf("Source cleanup warning: %v", err)
 		}
 		if err := transfer.Cleanup(context.TODO(), destClient, destPVC.Namespace, destPVC.Name); err != nil {
-			log.Printf("WARN: destination cleanup: %v", err)
+			log.Warnf("Destination cleanup warning: %v", err)
 		}
 		fmt.Fprintf(os.Stderr, "[6/6] Cleaning up transfer pods ... ok\n")
 	}()
@@ -152,9 +164,10 @@ func (t *TransferPVCCommand) runIndirect() error {
 	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ...\n")
 	uploadPod, err := transfer.Upload(context.TODO(), srcPVC)
 	if err != nil {
+		log.Debugf("Upload failed: %v", err)
 		return fmt.Errorf("upload failed: %w", err)
 	}
-	if err := followPodLogsUntilComplete(srcCfg, srcClient, uploadPod.Name, uploadPod.Namespace, "rclone"); err != nil {
+	if err := followPodLogsUntilComplete(srcCfg, srcClient, uploadPod.Name, uploadPod.Namespace, "rclone", log); err != nil {
 		return fmt.Errorf("upload pod failed: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[3/6] Uploading data to cloud storage ... ok\n")
@@ -163,9 +176,10 @@ func (t *TransferPVCCommand) runIndirect() error {
 	fmt.Fprintf(os.Stderr, "[4/6] Downloading data from cloud storage ...\n")
 	downloadPod, err := transfer.Download(context.TODO(), destPVC, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
+		log.Debugf("Download failed: %v", err)
 		return fmt.Errorf("download failed: %w", err)
 	}
-	if err := followPodLogsUntilComplete(destCfg, destClient, downloadPod.Name, downloadPod.Namespace, "rclone"); err != nil {
+	if err := followPodLogsUntilComplete(destCfg, destClient, downloadPod.Name, downloadPod.Namespace, "rclone", log); err != nil {
 		return fmt.Errorf("download pod failed: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "[4/6] Downloading data from cloud storage ... ok\n")
@@ -185,9 +199,10 @@ func (t *TransferPVCCommand) runIndirect() error {
 	return nil
 }
 
-func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, namespace, containerName string) error {
+func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, namespace, containerName string, log *logrus.Logger) error {
 	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
+		log.Debugf("Failed to create clientset: %v", err)
 		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
@@ -206,6 +221,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 			return false, nil
 		}
 	}); err != nil {
+		log.Debugf("Timed out waiting for pod %s/%s to start: %v", namespace, podName, err)
 		return fmt.Errorf("timed out waiting for pod %s/%s to start: %w", namespace, podName, err)
 	}
 
@@ -216,11 +232,12 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 	})
 	stream, err := req.Stream(context.TODO())
 	if err != nil {
+		log.Debugf("Failed to stream logs for pod %s/%s: %v", namespace, podName, err)
 		return fmt.Errorf("failed to stream logs for pod %s/%s: %w", namespace, podName, err)
 	}
 	defer func() {
 		if closeErr := stream.Close(); closeErr != nil {
-			log.Printf("WARN: failed to close log stream for pod %s/%s: %v", namespace, podName, closeErr)
+			log.Warnf("Failed to close log stream for pod %s/%s: %v", namespace, podName, closeErr)
 		}
 	}()
 
@@ -230,6 +247,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 		n, readErr := stream.Read(buf)
 		if n > 0 {
 			if _, writeErr := os.Stderr.Write(buf[:n]); writeErr != nil {
+				log.Debugf("Failed to write logs for pod %s/%s: %v", namespace, podName, writeErr)
 				return fmt.Errorf("failed to write logs for pod %s/%s: %w", namespace, podName, writeErr)
 			}
 			logOutput.Write(buf[:n])
@@ -247,6 +265,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 	if err := wait.PollUntilContextCancel(waitCtx, 3*time.Second, true, func(ctx context.Context) (bool, error) {
 		pod := &corev1.Pod{}
 		if err := c.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+			log.Debugf("Failed to get pod status for %s/%s: %v", namespace, podName, err)
 			return false, fmt.Errorf("failed to get pod status: %w", err)
 		}
 		switch pod.Status.Phase {
@@ -259,11 +278,12 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 			return false, nil
 		}
 	}); err != nil {
+		log.Errorf("Failed waiting for pod %s/%s terminal state: %v", namespace, podName, err)
 		return err
 	}
 
 	if podFailed {
-		return checkRclonePartialSuccess(logOutput.String(), podName, namespace)
+		return checkRclonePartialSuccess(logOutput.String(), podName, namespace, log)
 	}
 	return nil
 }
@@ -274,7 +294,7 @@ func followPodLogsUntilComplete(restCfg *rest.Config, c client.Client, podName, 
 // This function detects that case and treats it as success when files were transferred.
 // It returns an error only when no files were transferred or the failure is not
 // a permission issue.
-func checkRclonePartialSuccess(output, podName, namespace string) error {
+func checkRclonePartialSuccess(output, podName, namespace string, log *logrus.Logger) error {
 	// Parse the last "Transferred: N / M, P%" file count line
 	var lastTransferred, lastTotal int
 	fileCountFound := false
@@ -306,25 +326,29 @@ func checkRclonePartialSuccess(output, podName, namespace string) error {
 	}
 
 	if !fileCountFound {
+		log.Debugf("Pod %s/%s failed: no file count found in rclone output", namespace, podName)
 		return fmt.Errorf("pod %s/%s failed", namespace, podName)
 	}
 
 	if lastTransferred == 0 && lastTotal > 0 {
+		log.Debugf("Pod %s/%s: rclone transferred 0 of %d files", namespace, podName, lastTotal)
 		return fmt.Errorf("pod %s/%s: rclone transferred 0 of %d files — all files may be unreadable (check UID/permissions)",
 			namespace, podName, lastTotal)
 	}
 
 	hasPermissionError := strings.Contains(output, "permission denied")
 	if lastTransferred > 0 && hasPermissionError {
-		log.Printf("WARN: rclone completed with permission errors on %d of %d items (unreadable directories skipped)",
+		log.Warnf("Rclone completed with permission errors on %d of %d items (unreadable directories skipped)",
 			lastTotal-lastTransferred, lastTotal)
 		return nil
 	}
 
+	log.Debugf("Pod %s/%s failed", namespace, podName)
 	return fmt.Errorf("pod %s/%s failed", namespace, podName)
 }
 
 func (t *TransferPVCCommand) createTempRcloneSecretFromData(c client.Client, namespace string, configData []byte, labelPVCName string) (string, error) {
+	log := t.globalFlags.GetLoggerOrDefault()
 	secretName := fmt.Sprintf("crane-rclone-config-%s", getValidatedResourceName(t.PVC.Name.source))
 
 	secret := &corev1.Secret{
@@ -347,13 +371,16 @@ func (t *TransferPVCCommand) createTempRcloneSecretFromData(c client.Client, nam
 	if errors.IsAlreadyExists(err) {
 		existing := &corev1.Secret{}
 		if getErr := c.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: namespace}, existing); getErr != nil {
+			log.Debugf("Failed to get existing rclone secret %q: %v", secretName, getErr)
 			return "", fmt.Errorf("failed to get existing rclone secret: %w", getErr)
 		}
 		existing.Data = secret.Data
 		if updateErr := c.Update(context.TODO(), existing); updateErr != nil {
+			log.Debugf("Failed to update rclone secret %q: %v", secretName, updateErr)
 			return "", fmt.Errorf("failed to update rclone secret: %w", updateErr)
 		}
 	} else if err != nil {
+		log.Debugf("Failed to create rclone secret %q: %v", secretName, err)
 		return "", fmt.Errorf("failed to create rclone secret: %w", err)
 	}
 
@@ -363,13 +390,14 @@ func (t *TransferPVCCommand) createTempRcloneSecretFromData(c client.Client, nam
 // generateCryptSection creates the [encrypted] crypt overlay section for rclone.conf
 // with an auto-generated password. The password is random per transfer — encryption
 // is for data-in-transit in the bucket, not long-term storage.
-func generateCryptSection(cloudStoragePath string) (string, error) {
+func generateCryptSection(cloudStoragePath string, log *logrus.Logger) (string, error) {
 	password := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, password); err != nil {
+		log.Debugf("Failed to generate encryption password: %v", err)
 		return "", fmt.Errorf("failed to generate encryption password: %w", err)
 	}
 
-	obscured, err := rcloneObscure(base64.RawURLEncoding.EncodeToString(password))
+	obscured, err := rcloneObscure(base64.RawURLEncoding.EncodeToString(password), log)
 	if err != nil {
 		return "", fmt.Errorf("failed to obscure encryption password: %w", err)
 	}
@@ -379,7 +407,7 @@ func generateCryptSection(cloudStoragePath string) (string, error) {
 
 // rcloneObscure encodes a plaintext password in rclone's obscured format.
 // This is AES-CTR with rclone's well-known key, identical to "rclone obscure".
-func rcloneObscure(plaintext string) (string, error) {
+func rcloneObscure(plaintext string, log *logrus.Logger) (string, error) {
 	key := []byte{
 		0x9c, 0x93, 0x5b, 0x48, 0x73, 0x0a, 0x55, 0x4d,
 		0x6b, 0xfd, 0x7c, 0x63, 0xc8, 0x86, 0xa9, 0x2b,
@@ -388,11 +416,13 @@ func rcloneObscure(plaintext string) (string, error) {
 	}
 	block, err := aes.NewCipher(key)
 	if err != nil {
+		log.Errorf("Failed to create AES cipher: %v", err)
 		return "", err
 	}
 	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
 	iv := ciphertext[:aes.BlockSize]
 	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		log.Errorf("Failed to generate IV: %v", err)
 		return "", err
 	}
 	stream := cipher.NewCTR(block, iv)

--- a/cmd/transfer-pvc/indirect_test.go
+++ b/cmd/transfer-pvc/indirect_test.go
@@ -6,11 +6,13 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+
+	"github.com/sirupsen/logrus"
 )
 
 func TestRcloneObscure(t *testing.T) {
 	original := "test-encryption-password-42"
-	obscured, err := rcloneObscure(original)
+	obscured, err := rcloneObscure(original, logrus.StandardLogger())
 	if err != nil {
 		t.Fatalf("rcloneObscure() error: %v", err)
 	}
@@ -32,15 +34,15 @@ func TestRcloneObscure(t *testing.T) {
 }
 
 func TestRcloneObscure_DifferentOutputEachCall(t *testing.T) {
-	a, _ := rcloneObscure("same-input")
-	b, _ := rcloneObscure("same-input")
+	a, _ := rcloneObscure("same-input", logrus.StandardLogger())
+	b, _ := rcloneObscure("same-input", logrus.StandardLogger())
 	if a == b {
 		t.Error("two calls with same input should produce different output (random IV)")
 	}
 }
 
 func TestGenerateCryptSection(t *testing.T) {
-	section, err := generateCryptSection("remote:my-bucket/ns/pvc")
+	section, err := generateCryptSection("remote:my-bucket/ns/pvc", logrus.StandardLogger())
 	if err != nil {
 		t.Fatalf("generateCryptSection() error: %v", err)
 	}
@@ -99,7 +101,7 @@ func TestCheckRclonePartialSuccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := checkRclonePartialSuccess(tt.output, "test-pod", "test-ns")
+			err := checkRclonePartialSuccess(tt.output, "test-pod", "test-ns", logrus.StandardLogger())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("checkRclonePartialSuccess() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"os"
 	"regexp"
@@ -21,6 +20,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sirupsen/logrus"
 )
 
 type rsyncLogStream struct {
@@ -32,9 +33,10 @@ type rsyncLogStream struct {
 	err        chan error
 	progress   *Progress
 	outputFile *string
+	log        *logrus.Logger
 }
 
-func NewRsyncLogStream(restCfg *rest.Config, pvc types.NamespacedName, labels map[string]string, output string) LogStreams {
+func NewRsyncLogStream(restCfg *rest.Config, pvc types.NamespacedName, labels map[string]string, output string, log *logrus.Logger) LogStreams {
 	var outputFile string
 	if output != "" {
 		outputFile = output
@@ -44,6 +46,7 @@ func NewRsyncLogStream(restCfg *rest.Config, pvc types.NamespacedName, labels ma
 		pvc:        pvc,
 		podLabels:  labels,
 		outputFile: &outputFile,
+		log:        log,
 	}
 }
 
@@ -57,7 +60,7 @@ func (r *rsyncLogStream) Init() error {
 		return err
 	}
 
-	podName, err := waitForPodRunning(clientset, r.pvc.Namespace, r.podLabels)
+	podName, err := waitForPodRunning(clientset, r.pvc.Namespace, r.podLabels, r.log)
 	if err != nil {
 		return err
 	}
@@ -488,7 +491,7 @@ func parseRsyncLogs(rawLogs string) (p *Progress, unprocessedData string) {
 	return p, ""
 }
 
-func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[string]string) (string, error) {
+func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[string]string, log *logrus.Logger) (string, error) {
 	var podName string
 	err := wait.PollUntil(time.Second, func() (done bool, err error) {
 		listOptions := &client.ListOptions{}
@@ -500,7 +503,7 @@ func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[str
 		}
 
 		if len(clientPodList.Items) != 1 {
-			log.Printf("expected 1 client pod found %d, with labels %v\n", len(clientPodList.Items), labels)
+			log.Debugf("Expected 1 client pod, found %d with labels %v", len(clientPodList.Items), labels)
 			return false, nil
 		}
 
@@ -509,11 +512,11 @@ func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[str
 
 		for _, containerStatus := range clientPod.Status.ContainerStatuses {
 			if containerStatus.State.Terminated != nil {
-				log.Printf("container %s in pod %s completed", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name})
+				log.Debugf("Container %s in pod %s completed", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name})
 				break
 			}
 			if !containerStatus.Ready {
-				log.Println(fmt.Errorf("container %s in pod %s is not ready", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name}))
+				log.Debugf("Container %s in pod %s is not ready", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name})
 				return false, nil
 			}
 		}

--- a/cmd/transfer-pvc/progress.go
+++ b/cmd/transfer-pvc/progress.go
@@ -503,7 +503,7 @@ func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[str
 		}
 
 		if len(clientPodList.Items) != 1 {
-			log.Debugf("Expected 1 client pod, found %d with labels %v", len(clientPodList.Items), labels)
+			log.Warnf("Expected 1 client pod, found %d with labels %v", len(clientPodList.Items), labels)
 			return false, nil
 		}
 
@@ -516,7 +516,7 @@ func waitForPodRunning(c *kubernetes.Clientset, namespace string, labels map[str
 				break
 			}
 			if !containerStatus.Ready {
-				log.Debugf("Container %s in pod %s is not ready", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name})
+				log.Warnf("Container %s in pod %s is not ready, retrying...", containerStatus.Name, client.ObjectKey{Namespace: namespace, Name: clientPod.Name})
 				return false, nil
 			}
 		}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -243,6 +243,7 @@ func (t *TransferPVCCommand) Validate() error {
 	log := t.globalFlags.GetLoggerOrDefault()
 
 	if t.Flags.KeepCloudData && t.Flags.CloudStorage == "" {
+		log.Debugf("--keep-cloud-data requires --cloud-storage")
 		return fmt.Errorf("--keep-cloud-data requires --cloud-storage")
 	}
 	if t.sourceContext == nil {

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -649,7 +649,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	phases.End("finished", detail)
 
 	// ---- Phase 7/8: Cleanup ----
-	log.Infof("Phase 7/8: Cleanup")
+	log.Infof("Phase %d: Cleanup", totalPhases)
 	if t.isIntraClusterSameNamespace() {
 		phases.Start("Cleaning up server resources")
 		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konveyor/crane/internal/cli"
+	"github.com/konveyor/crane/internal/flags"
 
 	"github.com/migtools/pvc-transfer/endpoint"
 	ingressendpoint "github.com/migtools/pvc-transfer/endpoint/ingress"
@@ -58,7 +59,9 @@ const (
 type TransferPVCCommand struct {
 	configFlags *genericclioptions.ConfigFlags
 	genericclioptions.IOStreams
-	logger logrus.FieldLogger
+	globalFlags *flags.GlobalFlags
+	log         *logrus.Logger
+	logger      logrus.FieldLogger
 
 	sourceContext      *clientcmdapi.Context
 	destinationContext *clientcmdapi.Context
@@ -141,7 +144,7 @@ func (p *PvcFlags) Validate() error {
 	return nil
 }
 
-func NewTransferPVCCommand(streams genericclioptions.IOStreams) *cobra.Command {
+func NewTransferPVCCommand(streams genericclioptions.IOStreams, f *flags.GlobalFlags) *cobra.Command {
 	t := &TransferPVCCommand{
 		configFlags: genericclioptions.NewConfigFlags(false),
 		Flags: Flags{
@@ -151,8 +154,9 @@ func NewTransferPVCCommand(streams genericclioptions.IOStreams) *cobra.Command {
 				StorageRequests: quantityVar{},
 			},
 		},
-		IOStreams: streams,
-		logger:    logrus.New(),
+		IOStreams:    streams,
+		globalFlags: f,
+		logger:      logrus.New(),
 	}
 
 	cmd := &cobra.Command{
@@ -203,9 +207,11 @@ func addFlagsToTransferPVCCommand(c *Flags, cmd *cobra.Command) {
 }
 
 func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
+	t.log = t.globalFlags.GetLoggerOrDefault()
 	config := t.configFlags.ToRawKubeConfigLoader()
 	rawConfig, err := config.RawConfig()
 	if err != nil {
+		t.log.Errorf("Failed to load kubeconfig: %v", err)
 		return err
 	}
 
@@ -234,31 +240,40 @@ func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
 }
 
 func (t *TransferPVCCommand) Validate() error {
+	log := t.globalFlags.GetLoggerOrDefault()
+
 	if t.sourceContext == nil {
+		log.Debugf("Cannot evaluate source context")
 		return fmt.Errorf("cannot evaluate source context")
 	}
 
 	if t.destinationContext == nil {
+		log.Debugf("Cannot evaluate destination context")
 		return fmt.Errorf("cannot evaluate destination context")
 	}
 
 	if t.isIntraClusterSameNamespace() && t.PVC.Name.source == t.PVC.Name.destination {
+		log.Debugf("Source and destination PVC names must differ for same-cluster same-namespace transfers")
 		return fmt.Errorf("source and destination PVC names must differ for same-cluster same-namespace transfers")
 	}
 
 	err := t.PVC.Validate()
 	if err != nil {
+		log.Errorf("PVC validation failed: %v", err)
 		return err
 	}
 
 	if t.Flags.CloudStorage != "" {
 		if t.Flags.RcloneConfigSecret == "" && t.Flags.RcloneConfigFile == "" {
+			log.Debugf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")
 			return fmt.Errorf("--cloud-storage requires --rclone-config-secret or --rclone-config-file")
 		}
 		if t.Flags.RcloneConfigSecret != "" && t.Flags.RcloneConfigFile != "" {
+			log.Debugf("--rclone-config-secret and --rclone-config-file are mutually exclusive")
 			return fmt.Errorf("--rclone-config-secret and --rclone-config-file are mutually exclusive")
 		}
 		if t.Flags.Encrypt && t.Flags.RcloneConfigSecret != "" {
+			log.Debugf("--encrypt requires --rclone-config-file; it cannot be used with --rclone-config-secret")
 			return fmt.Errorf("--encrypt requires --rclone-config-file; it cannot be used with --rclone-config-secret")
 		}
 		return nil
@@ -266,6 +281,7 @@ func (t *TransferPVCCommand) Validate() error {
 
 	err = t.Endpoint.Validate()
 	if err != nil {
+		log.Errorf("Endpoint validation failed: %v", err)
 		return err
 	}
 
@@ -317,6 +333,8 @@ func (t *TransferPVCCommand) getRestConfigFromContext(ctx string) (*rest.Config,
 }
 
 func (t *TransferPVCCommand) run() (retErr error) {
+	log := t.globalFlags.GetLoggerOrDefault()
+	log.Infof("Starting PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
 	logrusLog := logrus.New()
 	logrusLog.SetFormatter(&logrus.JSONFormatter{})
 	logger := logrusr.New(logrusLog).WithName("transfer-pvc")
@@ -346,17 +364,21 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	)
 
 	// ---- Phase 1: Reading source PVC ----
+	log.Infof("Phase 1: Reading source PVC")
 	phases.Start("Reading source PVC")
 	srcCfg, err := t.getRestConfigFromContext(t.Flags.SourceContext)
 	if err != nil {
+		log.Errorf("Unable to get source rest config: %v", err)
 		return phases.Fail(err, "unable to get source rest config")
 	}
 	srcClient, err := t.getClientFromContext(t.Flags.SourceContext)
 	if err != nil {
+		log.Errorf("Unable to get source client: %v", err)
 		return phases.Fail(err, "unable to get source client")
 	}
 	destClient, err := t.getClientFromContext(t.Flags.DestinationContext)
 	if err != nil {
+		log.Errorf("Unable to get destination client: %v", err)
 		return phases.Fail(err, "unable to get destination client")
 	}
 	srcPVC := &corev1.PersistentVolumeClaim{}
@@ -369,15 +391,18 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		srcPVC,
 	)
 	if err != nil {
+		log.Errorf("Unable to get source PVC %s/%s: %v", t.PVC.Namespace.source, t.PVC.Name.source, err)
 		return phases.Fail(err, "unable to get source PVC")
 	}
 	phases.End("ok", "")
 
 	// ---- Phase 2: Creating destination PVC ----
+	log.Infof("Phase 2: Creating destination PVC")
 	phases.Start("Creating destination PVC")
 	destPVC := t.buildDestinationPVC(srcPVC)
 	err = destClient.Create(context.TODO(), destPVC, &client.CreateOptions{})
 	if err != nil && !errors.IsAlreadyExists(err) {
+		log.Errorf("Unable to create destination PVC %s/%s: %v", t.PVC.Namespace.destination, t.PVC.Name.destination, err)
 		return phases.Fail(err, "unable to create destination PVC")
 	}
 	phases.End("ok", "")
@@ -401,21 +426,26 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	}
 
 	// ---- Phase 3: Creating endpoint ----
+	log.Infof("Phase 3: Creating endpoint (%s)", t.Endpoint.Type)
 	phases.Start(fmt.Sprintf("Creating endpoint (%s)", t.Endpoint.Type))
 	e, err := createEndpoint(t.Endpoint, destPVC, labels, logger, destClient)
 	if err != nil {
+		log.Errorf("Failed creating endpoint: %v", err)
 		return phases.Fail(err, "failed creating endpoint")
 	}
 	phases.End("ok", "")
 
 	// ---- Phase 4: Waiting for endpoint healthy ----
+	log.Infof("Phase 4: Waiting for endpoint healthy")
 	phases.Start("Waiting for endpoint healthy")
 	if err := waitForEndpoint(e, destClient); err != nil {
+		log.Errorf("Endpoint not healthy: %v", err)
 		return phases.Fail(err, "endpoint not healthy")
 	}
 	phases.End("ok", "")
 
 	// ---- Phase 5: Setting up secure tunnel and server ----
+	log.Infof("Phase 5: Setting up secure tunnel and server")
 	phases.Start("Setting up secure tunnel and server")
 	stunnelServer, err := stunneltransport.NewServer(
 		context.TODO(),
@@ -429,6 +459,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 			Image:  t.Flags.DestinationImage,
 		})
 	if err != nil {
+		log.Errorf("Error creating stunnel server: %v", err)
 		return phases.Fail(err, "error creating stunnel server")
 	}
 
@@ -439,6 +470,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		client.InNamespace(destPVC.Namespace),
 		client.MatchingLabels(labels))
 	if err != nil {
+		log.Errorf("Failed to find certificate secrets: %v", err)
 		return phases.Fail(err, "failed to find certificate secrets")
 	}
 
@@ -463,6 +495,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		if errors.IsAlreadyExists(err) {
 			existing := &corev1.Secret{}
 			if getErr := srcClient.Get(context.TODO(), client.ObjectKey{Name: secretName, Namespace: srcPVC.Namespace}, existing); getErr != nil {
+				log.Errorf("Failed to get existing certificate Secret %q: %v", secretName, getErr)
 				return phases.Fail(getErr, fmt.Sprintf("failed to get existing certificate Secret %q", secretName))
 			}
 			existing.Data = destSecret.Data
@@ -470,9 +503,11 @@ func (t *TransferPVCCommand) run() (retErr error) {
 			existing.Labels = secretLabels
 			existing.Annotations = destSecret.Annotations
 			if updateErr := srcClient.Update(context.TODO(), existing); updateErr != nil {
+				log.Errorf("Failed to update certificate Secret %q: %v", secretName, updateErr)
 				return phases.Fail(updateErr, fmt.Sprintf("failed to update certificate Secret %q", secretName))
 			}
 		} else if err != nil {
+			log.Errorf("Failed to create certificate Secret %q: %v", secretName, err)
 			return phases.Fail(err, fmt.Sprintf("failed to create certificate Secret %q", secretName))
 		}
 	}
@@ -490,6 +525,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		},
 	)
 	if err != nil {
+		log.Errorf("Error creating stunnel client: %v", err)
 		return phases.Fail(err, "error creating stunnel client")
 	}
 
@@ -498,11 +534,13 @@ func (t *TransferPVCCommand) run() (retErr error) {
 
 	clientPodSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
+		log.Errorf("Error creating security context for rsync client: %v", err)
 		return phases.Fail(err, "error creating security context for rsync client")
 	}
 
 	serverPodSecContext, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name)
 	if err != nil {
+		log.Errorf("Error creating security context for rsync server: %v", err)
 		return phases.Fail(err, "error creating security context for rsync server")
 	}
 	if serverPodSecContext.RunAsUser == nil && clientPodSecCtx.RunAsUser != nil {
@@ -535,6 +573,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		},
 	)
 	if err != nil {
+		log.Errorf("Error creating rsync transfer server: %v", err)
 		return phases.Fail(err, "error creating rsync transfer server")
 	}
 
@@ -554,9 +593,11 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	phases.End("ok", "")
 
 	// ---- Phase 6: Copying data (rsync) ----
+	log.Infof("Phase 6: Copying data (rsync)")
 	phases.Start("Copying data (rsync)")
 	nodeName, err := getNodeNameForPVC(srcClient, srcPVC.Namespace, srcPVC.Name)
 	if err != nil {
+		log.Errorf("Failed to find node name for PVC %s/%s: %v", srcPVC.Namespace, srcPVC.Name, err)
 		return phases.Fail(err, "failed to find node name")
 	}
 
@@ -587,12 +628,14 @@ func (t *TransferPVCCommand) run() (retErr error) {
 		},
 	)
 	if err != nil {
+		log.Errorf("Failed to create rsync client: %v", err)
 		return phases.Fail(err, "failed to create rsync client")
 	}
 
 	exitCode, err := followClientLogs(
-		srcCfg, types.NamespacedName{Name: srcPVC.Name, Namespace: srcPVC.Namespace}, clientLabels, t.ProgressOutput)
+		srcCfg, types.NamespacedName{Name: srcPVC.Name, Namespace: srcPVC.Namespace}, clientLabels, t.ProgressOutput, log)
 	if err != nil {
+		log.Errorf("Error following rsync client logs: %v", err)
 		return phases.Fail(err, "error following rsync client logs")
 	}
 	detail := ""
@@ -602,26 +645,31 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	phases.End("finished", detail)
 
 	// ---- Phase 7/8: Cleanup ----
+	log.Infof("Phase 7/8: Cleanup")
 	if t.isIntraClusterSameNamespace() {
 		phases.Start("Cleaning up server resources")
 		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			log.Warnf("Server-side cleanup warning: %v", err)
 			fmt.Fprintf(t.ErrOut, "  WARN: %v\n", err)
 		}
 		phases.End("ok", "")
 
 		phases.Start("Cleaning up client resources")
 		if err := garbageCollect(srcClient, destClient, clientLabels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			log.Errorf("Client-side cleanup failed: %v", err)
 			return phases.Fail(err, "client-side cleanup failed")
 		}
 		phases.End("ok", "")
 	} else {
 		phases.Start("Cleaning up temporary resources")
 		if err := garbageCollect(srcClient, destClient, labels, t.Endpoint.Type, t.PVC.Namespace); err != nil {
+			log.Errorf("Cleanup failed: %v", err)
 			return phases.Fail(err, "cleanup failed")
 		}
 		phases.End("ok", "")
 	}
 
+	log.Infof("PVC transfer complete: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
 	return nil
 }
 
@@ -1084,8 +1132,8 @@ type LogStreams interface {
 	ExitCode() *int32
 }
 
-func followClientLogs(srcConfig *rest.Config, pvc types.NamespacedName, labels map[string]string, outputFile string) (*int32, error) {
-	logReader := NewRsyncLogStream(srcConfig, pvc, labels, outputFile)
+func followClientLogs(srcConfig *rest.Config, pvc types.NamespacedName, labels map[string]string, outputFile string, log *logrus.Logger) (*int32, error) {
+	logReader := NewRsyncLogStream(srcConfig, pvc, labels, outputFile, log)
 	err := logReader.Init()
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 	}
 	f.ApplyFlags(&root)
 	root.AddCommand(export.NewExportCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
-	root.AddCommand(transfer_pvc.NewTransferPVCCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
+	root.AddCommand(transfer_pvc.NewTransferPVCCommand(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}, f))
 	root.AddCommand(tunnel_api.NewTunnelAPIOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
 	root.AddCommand(convert.NewConvertOptions(genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}))
 	root.AddCommand(transform.NewTransformCommand(f))


### PR DESCRIPTION
https://github.com/migtools/crane/issues/781
Adds missing log statements across transfer-pvc commands as a first step toward the persistent audit log feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced progress and diagnostic logging throughout PVC transfers.
  * Added clearer debug, warning, and error messages for transfer phases, pod monitoring, cleanup, encryption, and partial outcomes.
  * Integrated transfer-PVC operations with the application’s shared logging configuration.
  * Transfer operations now consistently use the selected source image for setup and execution.
  * Improved reporting for configuration issues, security-context fallbacks, secret handling, and cleanup activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->