### PR TITLE
:sparkles: add support for cloud data cleanup

### DIFF
--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -168,10 +168,21 @@ func (t *TransferPVCCommand) runIndirect() error {
 
 	// Cleanup cloud data
 	fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ...\n")
-	if !t.Flags.KeepCloudData {
-		fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... skipped (not implemented yet)\n")
-	} else {
+	if t.Flags.KeepCloudData {
 		fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... skipped (--keep-cloud-data)\n")
+	} else {
+		cleanupPod, err := transfer.CleanupCloudData(context.TODO(), srcClient, srcPVC.Namespace, srcPVC.Name, srcPVC.Namespace, srcPVC.Name)
+		if err != nil {
+			log.Printf("WARN: cloud storage cleanup failed to start: %v", err)
+			fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... failed (non-fatal)\n")
+		} else {
+			if err := followPodLogsUntilComplete(srcCfg, srcClient, cleanupPod.Name, cleanupPod.Namespace, "rclone"); err != nil {
+				log.Printf("WARN: cloud storage cleanup failed: %v", err)
+				fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... failed (non-fatal)\n")
+			} else {
+				fmt.Fprintf(os.Stderr, "[5/6] Cleaning up cloud storage ... ok\n")
+			}
+		}
 	}
 
 	fmt.Fprintf(os.Stderr, "\nSummary\n-------\n")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/konveyor/crane-lib v0.1.6-0.20260823185453-0508f29d427a
-	github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821
+	github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d
-	github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a
+	github.com/konveyor/crane-lib v0.1.6-0.20260823185453-0508f29d427a
+	github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.0
@@ -29,7 +29,6 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/cli-runtime v0.35.3
 	k8s.io/client-go v0.35.3
-	k8s.io/component-helpers v0.35.3
 	sigs.k8s.io/controller-runtime v0.23.3
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kustomize/v5 v5.8.1
@@ -101,6 +100,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/component-helpers v0.35.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -382,6 +382,8 @@ github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821 h1:C84du165fwGWJY40kr2bbpxMiECFO6JNI6ELKJHjy2I=
 github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
+github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a h1:bSsyUn96V8oLl6S//jWK78nHicx5u7Wr7qhPSZYbZkI=
+github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,12 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d h1:ynlHX9Rg4+qAuP0uSn24MyIOQMvW1JJz/p0A+045y78=
-github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee h1:T3i160U9L0PjkleTXOFpoyAS/npIc8oG9XBlEjE/Uo8=
+github.com/konveyor/crane-lib v0.1.6-0.20260807130033-222a325c7cee/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1 h1:TfmdlBmsUSisxVDIREk0SrV+xAi7fmp27Yn+609cCFU=
+github.com/konveyor/crane-lib v0.1.6-0.20260818123419-d279d85c1dd1/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260823185453-0508f29d427a h1:VE5HVOkm0JmDKCGm7zT1S0INYHULBER7rUSmlL0q+HQ=
+github.com/konveyor/crane-lib v0.1.6-0.20260823185453-0508f29d427a/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -376,8 +380,8 @@ github.com/maxatome/go-testdeep v1.11.0/go.mod h1:011SgQ6efzZYAen6fDn4BqQ+lUR72y
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a h1:bSsyUn96V8oLl6S//jWK78nHicx5u7Wr7qhPSZYbZkI=
-github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
+github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821 h1:C84du165fwGWJY40kr2bbpxMiECFO6JNI6ELKJHjy2I=
+github.com/migtools/pvc-transfer v0.0.0-20260805073413-1b1f9d254821/go.mod h1:ep8dIwq9ZA5oIQKzYL0eVMugUaNWOfIr1fAq02yURgo=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=


### PR DESCRIPTION
## Summary

  Implement cloud storage cleanup after successful indirect PVC transfer.

  ### Changes

  - **`cmd/transfer-pvc/indirect.go`**
    - Replaced the `"skipped (not implemented yet)"` placeholder at step 5 with actual cloud cleanup
    - Default: creates a cleanup pod via `transfer.CleanupCloudData()`, streams its logs, deletes transferred data from S3
    - With `--keep-cloud-data`: skips cleanup with a message
    - Cleanup failure is a warning, not an error — the transfer already succeeded

  ### Behavior

  Without --keep-cloud-data (default):
    [5/6] Cleaning up cloud storage ...
    test.txt: Deleted
    Deleted: 1 (files), 0 (dirs), 22 B (freed)
    [5/6] Cleaning up cloud storage ... ok

  With --keep-cloud-data:
    [5/6] Cleaning up cloud storage ... skipped (--keep-cloud-data)

  On cleanup failure:
    WARN: cloud storage cleanup failed: <error>
    [5/6] Cleaning up cloud storage ... failed (non-fatal)
    EXIT: 0  (transfer still succeeds)

  ### Dependencies

  Requires crane-lib changes (separate PR) that add `CleanupCloudData()`.

  ### Tested locally

  - Default: S3 data deleted after transfer, target data intact
  - `--keep-cloud-data`: S3 data preserved, target data intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Indirect PVC transfers now automatically clean up associated cloud storage unless `--keep-cloud-data` is enabled.
  - Cleanup progress and successful completion are reported during the transfer.
  - Cleanup is skipped when cloud data is explicitly retained.

- **Bug Fixes**
  - Cleanup startup or execution failures are reported without causing the overall transfer to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->