### PR TITLE
:test_tube: Add MTA-900 e2e for same-cluster single-PVC StorageClass …

### DIFF
--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -21,6 +21,11 @@ import (
 	nodeaffinity "k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 )
 
+const (
+	defaultStorageClassAnnotation     = "storageclass.kubernetes.io/is-default-class"
+	defaultStorageClassBetaAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+)
+
 // ListPVCs returns PersistentVolumeClaims from a namespace, optionally filtered
 // by label selector, using the provided kubeconfig context.
 func ListPVCs(namespace string, labelSelector string, contextName string) ([]corev1.PersistentVolumeClaim, error) {
@@ -78,11 +83,16 @@ func DefaultStorageClassName(contextName string) (string, error) {
 		return "", fmt.Errorf("failed listing StorageClasses (context=%q): %w", contextName, err)
 	}
 	for i := range list.Items {
-		if list.Items[i].Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+		if hasDefaultStorageClassAnnotation(list.Items[i]) {
 			return list.Items[i].Name, nil
 		}
 	}
 	return "", fmt.Errorf("no default StorageClass found (context=%q)", contextName)
+}
+
+func hasDefaultStorageClassAnnotation(storageClass storagev1.StorageClass) bool {
+	return storageClass.Annotations[defaultStorageClassAnnotation] == "true" ||
+		storageClass.Annotations[defaultStorageClassBetaAnnotation] == "true"
 }
 
 // ResolvePVCStorageClass returns the PVC's StorageClass, falling back to the

--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -13,6 +13,8 @@ import (
 
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -40,6 +42,129 @@ func ListPVCs(namespace string, labelSelector string, contextName string) ([]cor
 
 	return pvcList.Items, nil
 
+}
+
+// GetPVC returns a PersistentVolumeClaim by name.
+func GetPVC(contextName, namespace, name string) (*corev1.PersistentVolumeClaim, error) {
+	clientSet, err := NewClientSetForContext(contextName)
+	if err != nil {
+		return nil, err
+	}
+	pvc, err := clientSet.CoreV1().PersistentVolumeClaims(namespace).Get(
+		context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed getting PVC %s/%s (context=%q): %w", namespace, name, contextName, err)
+	}
+	return pvc, nil
+}
+
+// PVCStorageClassName returns the StorageClass name from a PVC spec, or empty
+// when the claim uses the cluster default (unset storageClassName).
+func PVCStorageClassName(pvc corev1.PersistentVolumeClaim) string {
+	if pvc.Spec.StorageClassName != nil {
+		return *pvc.Spec.StorageClassName
+	}
+	return ""
+}
+
+// DefaultStorageClassName returns the name of the cluster default StorageClass.
+func DefaultStorageClassName(contextName string) (string, error) {
+	clientSet, err := NewClientSetForContext(contextName)
+	if err != nil {
+		return "", err
+	}
+	list, err := clientSet.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed listing StorageClasses (context=%q): %w", contextName, err)
+	}
+	for i := range list.Items {
+		if list.Items[i].Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return list.Items[i].Name, nil
+		}
+	}
+	return "", fmt.Errorf("no default StorageClass found (context=%q)", contextName)
+}
+
+// ResolvePVCStorageClass returns the PVC's StorageClass, falling back to the
+// cluster default when spec.storageClassName is unset.
+func ResolvePVCStorageClass(contextName string, pvc corev1.PersistentVolumeClaim) (string, error) {
+	if name := PVCStorageClassName(pvc); name != "" {
+		return name, nil
+	}
+	return DefaultStorageClassName(contextName)
+}
+
+// CloneStorageClass creates destName as a copy of sourceName's provisioner and
+// volume settings, without copying default-class annotations. If destName
+// already exists it is left unchanged. Source and dest names must differ.
+func CloneStorageClass(contextName, sourceName, destName string) error {
+	if sourceName == "" {
+		return fmt.Errorf("source StorageClass name is empty")
+	}
+	if destName == "" {
+		return fmt.Errorf("destination StorageClass name is empty")
+	}
+	if sourceName == destName {
+		return fmt.Errorf("destination StorageClass %q must differ from source %q", destName, sourceName)
+	}
+
+	clientSet, err := NewClientSetForContext(contextName)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	src, err := clientSet.StorageV1().StorageClasses().Get(ctx, sourceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get source StorageClass %q: %w", sourceName, err)
+	}
+
+	_, err = clientSet.StorageV1().StorageClasses().Get(ctx, destName, metav1.GetOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("get destination StorageClass %q: %w", destName, err)
+	}
+
+	clone := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: destName,
+			Labels: map[string]string{
+				"app.konveyor.io/e2e": "true",
+			},
+		},
+		Provisioner:          src.Provisioner,
+		Parameters:           src.Parameters,
+		ReclaimPolicy:        src.ReclaimPolicy,
+		MountOptions:         src.MountOptions,
+		AllowVolumeExpansion: src.AllowVolumeExpansion,
+		VolumeBindingMode:    src.VolumeBindingMode,
+		AllowedTopologies:    src.AllowedTopologies,
+	}
+	_, err = clientSet.StorageV1().StorageClasses().Create(ctx, clone, metav1.CreateOptions{})
+	if err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return fmt.Errorf("create StorageClass %q cloned from %q: %w", destName, sourceName, err)
+	}
+	return nil
+}
+
+// DeleteStorageClass deletes a StorageClass, treating NotFound as success.
+func DeleteStorageClass(contextName, name string) error {
+	if name == "" {
+		return nil
+	}
+	clientSet, err := NewClientSetForContext(contextName)
+	if err != nil {
+		return err
+	}
+	err = clientSet.StorageV1().StorageClasses().Delete(context.Background(), name, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete StorageClass %q: %w", name, err)
+	}
+	return nil
 }
 
 // VerifyPVCsExistByName checks that all source PVCs exist by name in the target PVC list.

--- a/e2e-tests/framework/client.go
+++ b/e2e-tests/framework/client.go
@@ -94,6 +94,46 @@ func ResolvePVCStorageClass(contextName string, pvc corev1.PersistentVolumeClaim
 	return DefaultStorageClassName(contextName)
 }
 
+// PrepareDestinationStorageClass returns a destination StorageClass name for
+// conversion tests. It prefers the first existing class whose name differs from
+// sourceName. If no alternative class exists, it falls back to cloning
+// sourceName into fallbackCloneName and returns a cleanup callback for the
+// temporary clone.
+func PrepareDestinationStorageClass(contextName, sourceName, fallbackCloneName string) (string, func() error, error) {
+	if sourceName == "" {
+		return "", nil, fmt.Errorf("source StorageClass name is empty")
+	}
+	if fallbackCloneName == "" {
+		return "", nil, fmt.Errorf("fallback clone StorageClass name is empty")
+	}
+	if fallbackCloneName == sourceName {
+		return "", nil, fmt.Errorf("fallback clone StorageClass %q must differ from source %q", fallbackCloneName, sourceName)
+	}
+
+	clientSet, err := NewClientSetForContext(contextName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	list, err := clientSet.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", nil, fmt.Errorf("failed listing StorageClasses (context=%q): %w", contextName, err)
+	}
+	for i := range list.Items {
+		if list.Items[i].Name != sourceName {
+			return list.Items[i].Name, func() error { return nil }, nil
+		}
+	}
+
+	if err := CloneStorageClass(contextName, sourceName, fallbackCloneName); err != nil {
+		return "", nil, err
+	}
+	cleanup := func() error {
+		return DeleteStorageClass(contextName, fallbackCloneName)
+	}
+	return fallbackCloneName, cleanup, nil
+}
+
 // CloneStorageClass creates destName as a copy of sourceName's provisioner and
 // volume settings, without copying default-class annotations. If destName
 // already exists it is left unchanged. Source and dest names must differ.

--- a/e2e-tests/framework/client_test.go
+++ b/e2e-tests/framework/client_test.go
@@ -1,0 +1,57 @@
+package framework
+
+import (
+	"testing"
+
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHasDefaultStorageClassAnnotation(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantDefault  bool
+	}{
+		{
+			name: "ga annotation marks default",
+			annotations: map[string]string{
+				defaultStorageClassAnnotation: "true",
+			},
+			wantDefault: true,
+		},
+		{
+			name: "beta annotation marks default",
+			annotations: map[string]string{
+				defaultStorageClassBetaAnnotation: "true",
+			},
+			wantDefault: true,
+		},
+		{
+			name: "false annotation is not default",
+			annotations: map[string]string{
+				defaultStorageClassAnnotation: "false",
+			},
+			wantDefault: false,
+		},
+		{
+			name:        "missing annotations is not default",
+			annotations: nil,
+			wantDefault: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			storageClass := storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+			}
+
+			if got := hasDefaultStorageClassAnnotation(storageClass); got != tt.wantDefault {
+				t.Fatalf("hasDefaultStorageClassAnnotation() = %v, want %v", got, tt.wantDefault)
+			}
+		})
+	}
+}

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -19,6 +19,7 @@ type TransferPVCOptions struct {
 	TargetContext      string
 	PVCName            string
 	PVCNamespaceMap    string
+	DestStorageClass   string
 	Endpoint           string
 	IngressClass       string
 	Subdomain          string
@@ -50,16 +51,16 @@ type ExportOptions struct {
 }
 
 type TransformOptions struct {
-	ExportDir         string
-	TransformDir      string
-	PluginDir         string
-	SkipPlugins       []string
-	OptionalFlags     string
-	StageOptionals    []string
-	Overwrite         bool
-	KustomizeArgs     string
-	InstructionsFile  string
-	Stages            []string
+	ExportDir        string
+	TransformDir     string
+	PluginDir        string
+	SkipPlugins      []string
+	OptionalFlags    string
+	StageOptionals   []string
+	Overwrite        bool
+	KustomizeArgs    string
+	InstructionsFile string
+	Stages           []string
 }
 
 type ApplyOptions struct {
@@ -214,6 +215,9 @@ func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
 		"--destination-context", opts.TargetContext,
 		"--pvc-name", opts.PVCName,
 		"--pvc-namespace", opts.PVCNamespaceMap,
+	}
+	if opts.DestStorageClass != "" {
+		args = append(args, "--dest-storage-class", opts.DestStorageClass)
 	}
 
 	if opts.CloudStorage != "" {

--- a/e2e-tests/framework/kubectl.go
+++ b/e2e-tests/framework/kubectl.go
@@ -27,6 +27,7 @@ func (k KubectlRunner) Run(args ...string) (string, error) {
 func (k KubectlRunner) RunWithStdin(stdin string, args ...string) (string, error) {
 	return k.executeWithStdin(stdin, args...)
 }
+
 // executeWithStdin executes an arbitrary kubectl command using stdin content.
 func (k KubectlRunner) executeWithStdin(stdin string, args ...string) (string, error) {
 	finalArgs := append([]string{}, normalizeKubectlArgs(args...)...)
@@ -363,6 +364,21 @@ func (k KubectlRunner) ScaleDeploymentIfPresent(ns, appName string, replicas int
 		return nil
 	}
 	return k.ScaleDeployment(ns, appName, replicas)
+}
+
+// GetResourceNamesByLabel returns resource names matching a label selector.
+// On OpenShift, Routes are included alongside pods, services, secrets,
+// configmaps, and ingresses.
+func (k KubectlRunner) GetResourceNamesByLabel(namespace, labelSelector string) (string, error) {
+	kinds := "pods,services,secrets,configmaps,ingresses"
+	if k.IsOpenShift() {
+		kinds += ",routes.route.openshift.io"
+	}
+	out, err := k.Run("get", kinds, "-n", namespace, "-l", labelSelector, "-o", "name")
+	if err != nil {
+		return "", err
+	}
+	return StripKubectlWarnings(out), nil
 }
 
 func (k KubectlRunner) CanI(verb, resource, namespace string) (bool, error) {

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -3,9 +3,9 @@ package framework
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
-    "os"
-    "path/filepath"
 
 	"github.com/konveyor/crane/e2e-tests/utils"
 	"github.com/onsi/gomega"
@@ -139,23 +139,33 @@ func ApplyOutputToTargetNonAdmin(kubectlTgt KubectlRunner, outputDir string) err
 	return applyOutputManifests(kubectlTgt, outputDir)
 }
 
-// ApplyOutputToTargetWithNamespaceRemap reads output.yaml, replaces all occurrences
+// ApplyOutputToTargetWithNamespaceRemap remaps namespace references in
+// output.yaml, creates the target namespace, and applies the result there.
 func ApplyOutputToTargetWithNamespaceRemap(kubectl KubectlRunner, srcNamespace, tgtNamespace, outputDir string) error {
-      content, err := os.ReadFile(filepath.Join(outputDir, "output.yaml"))
-      if err != nil {
-          return fmt.Errorf("reading output.yaml: %w", err)
-      }
-      remapped ,err := utils.RemapNamespaceInYAML(content, srcNamespace, tgtNamespace)
-	  if err != nil {
-          return fmt.Errorf("remapping namespace in output: %w", err)
-      }
-      if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
-        return fmt.Errorf("creating target namespace %q: %w", tgtNamespace, err)
-      }
-      if err := kubectl.ApplyYAMLSpec(remapped, tgtNamespace); err != nil {
-        return fmt.Errorf("applying remapped manifests to namespace %q: %w", tgtNamespace, err)
-      }
-return nil
+	remapped, err := remapOutputNamespaces(outputDir, srcNamespace, tgtNamespace)
+	if err != nil {
+		return err
+	}
+	if err := kubectl.CreateNamespace(tgtNamespace); err != nil {
+		return fmt.Errorf("creating target namespace %q: %w", tgtNamespace, err)
+	}
+	if err := kubectl.ApplyYAMLSpec(remapped, tgtNamespace); err != nil {
+		return fmt.Errorf("applying remapped manifests to namespace %q: %w", tgtNamespace, err)
+	}
+	return nil
+}
+
+// ApplyOutputToTargetWithNamespaceRemapNonAdmin validates and applies remapped
+// manifests without creating the target namespace.
+func ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectl KubectlRunner, srcNamespace, tgtNamespace, outputDir string) error {
+	remapped, err := remapOutputNamespaces(outputDir, srcNamespace, tgtNamespace)
+	if err != nil {
+		return err
+	}
+	if err := kubectl.ApplyYAMLSpec(remapped, tgtNamespace); err != nil {
+		return fmt.Errorf("applying remapped manifests to namespace %q: %w", tgtNamespace, err)
+	}
+	return nil
 }
 
 func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {
@@ -166,6 +176,20 @@ func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {
 		return err
 	}
 	return nil
+}
+
+// remapOutputNamespaces loads output.yaml and rewrites namespace references
+// from srcNamespace to tgtNamespace.
+func remapOutputNamespaces(outputDir, srcNamespace, tgtNamespace string) (string, error) {
+	content, err := os.ReadFile(filepath.Join(outputDir, "output.yaml"))
+	if err != nil {
+		return "", fmt.Errorf("reading output.yaml: %w", err)
+	}
+	remapped, err := utils.RemapNamespaceInYAML(content, srcNamespace, tgtNamespace)
+	if err != nil {
+		return "", fmt.Errorf("remapping namespace in output: %w", err)
+	}
+	return remapped, nil
 }
 
 // checkAndLogStageFiles validates stage output exists and logs the file list.

--- a/e2e-tests/framework/scenario.go
+++ b/e2e-tests/framework/scenario.go
@@ -34,6 +34,9 @@ func NewMigrationScenario(appName, namespace, k8sDeployBin, craneBin, srcCtx, tg
 	if config.RunAs == "admin" {
 		srcNonAdminCtx = srcCtx
 		tgtNonAdminCtx = tgtCtx
+	} else if srcCtx == tgtCtx {
+		// Same-cluster scenarios should reuse the source non-admin context on both sides.
+		tgtNonAdminCtx = srcNonAdminCtx
 	}
 
 	return MigrationScenario{

--- a/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
@@ -1,0 +1,143 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
+	It("[MTA-900] Convert a single PVC (Deployment) to a different StorageClass, same cluster", Label("tier0", "pvc-transfer"), func() {
+		const (
+			appName    = "mongodb"
+			pvcName    = "mongodb-data"
+			destSCName = "crane-dest-mta-900"
+		)
+		srcNamespace := "mta-900-src"
+		tgtNamespace := "mta-900-tgt"
+
+		scenario := NewMigrationScenario(
+			appName,
+			srcNamespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.SourceContext,
+		)
+		scenario.TgtApp.Namespace = tgtNamespace
+		srcApp := scenario.SrcApp
+		tgtApp := scenario.TgtApp
+		kubectlSrc := scenario.KubectlSrc
+		kubectlTgt := scenario.KubectlTgt
+		runner := scenario.Crane
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			By("Delete source and target namespaces")
+			for _, ns := range []string{srcNamespace, tgtNamespace} {
+				if _, err := kubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			}
+			By("Delete cloned destination StorageClass")
+			if err := DeleteStorageClass(srcApp.Context, destSCName); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+		})
+
+		By("Deploy and validate source MongoDB")
+		log.Printf("Preparing source app %s in namespace %s", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+
+		By("Resolve source StorageClass and clone a distinct destination class")
+		srcPVC, err := GetPVC(srcApp.Context, srcNamespace, pvcName)
+		Expect(err).NotTo(HaveOccurred())
+		srcSC, err := ResolvePVCStorageClass(srcApp.Context, *srcPVC)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(srcSC).NotTo(BeEmpty(), "source PVC %s/%s must have a StorageClass", srcNamespace, pvcName)
+		log.Printf("Source PVC %s/%s StorageClass=%s", srcNamespace, pvcName, srcSC)
+
+		Expect(CloneStorageClass(srcApp.Context, srcSC, destSCName)).NotTo(HaveOccurred())
+		Expect(destSCName).NotTo(Equal(srcSC))
+
+		By("Scale down source MongoDB so the RWO PVC is unmounted")
+		Expect(kubectlSrc.ScaleDeploymentIfPresent(srcNamespace, appName, 0)).NotTo(HaveOccurred())
+		_, err = kubectlSrc.Run("wait", "pod", "-n", srcNamespace, "-l", "name="+appName, "--for=delete", "--timeout=60s")
+		Expect(err).NotTo(HaveOccurred())
+		WaitForSourceQuiesce(kubectlSrc, srcNamespace, "name="+appName, appName)
+
+		By("Run crane export/transform/apply pipeline")
+		runner.WorkDir = paths.TempDir
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Create destination namespace and transfer PVC onto the cloned StorageClass")
+		Expect(kubectlTgt.CreateNamespace(tgtNamespace)).NotTo(HaveOccurred())
+
+		nodeIP, err := GetClusterNodeIP(srcApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		opts := TransferPVCOptions{
+			SourceContext:    srcApp.Context,
+			TargetContext:    tgtApp.Context,
+			PVCName:          pvcName,
+			PVCNamespaceMap:  fmt.Sprintf("%s:%s", srcNamespace, tgtNamespace),
+			DestStorageClass: destSCName,
+			Subdomain:        fmt.Sprintf("%s.nip.io", nodeIP),
+		}
+		log.Printf("Transferring PVC %s %s -> %s with dest StorageClass %s", pvcName, srcNamespace, tgtNamespace, destSCName)
+		Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
+
+		By("Wait for transfer-pvc helpers to finish deleting")
+		assertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
+
+		By("Assert destination PVC uses the converted StorageClass")
+		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, pvcName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PVCStorageClassName(*destPVC)).To(Equal(destSCName),
+			"destination PVC StorageClass should be %s", destSCName)
+
+		By("Apply remapped manifests to destination namespace")
+		Expect(ApplyOutputToTargetWithNamespaceRemap(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale destination MongoDB and validate data")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
+
+		By("Assert destination PVC is Bound after the workload starts")
+		destPVC, err = GetPVC(tgtApp.Context, tgtNamespace, pvcName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound))
+
+		By("Confirm no leftover transfer-pvc resources")
+		assertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
+	})
+})
+
+// assertNoTransferPVCLeftovers waits until transfer-pvc helper objects labeled
+// for pvcName are gone. DeleteAllOf in transfer-pvc GC is asynchronous, so the
+// rsync-server pod can still be Terminating for a while after the command exits.
+func assertNoTransferPVCLeftovers(k KubectlRunner, namespaces []string, pvcName string) {
+	selector := "app.konveyor.io/created-for-pvc=" + pvcName
+	for _, ns := range namespaces {
+		Eventually(func() (string, error) {
+			out, err := k.GetResourceNamesByLabel(ns, selector)
+			return strings.TrimSpace(out), err
+		}, "2m", "5s").Should(BeEmpty(),
+			"expected no leftover transfer-pvc resources in namespace %s", ns)
+	}
+}

--- a/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
@@ -16,9 +16,9 @@ import (
 var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 	It("[MTA-900] Convert a single PVC (Deployment) to a different StorageClass, same cluster", Label("tier0", "pvc-transfer"), func() {
 		const (
-			appName    = "mongodb"
-			pvcName    = "mongodb-data"
-			destSCName = "crane-dest-mta-900"
+			appName            = "mongodb"
+			pvcName            = "mongodb-data"
+			fallbackDestSCName = "crane-dest-mta-900"
 		)
 		srcNamespace := "mta-900-src"
 		tgtNamespace := "mta-900-tgt"
@@ -31,12 +31,25 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 			config.SourceContext,
 			config.SourceContext,
 		)
-		scenario.TgtApp.Namespace = tgtNamespace
-		srcApp := scenario.SrcApp
-		tgtApp := scenario.TgtApp
-		kubectlSrc := scenario.KubectlSrc
-		kubectlTgt := scenario.KubectlTgt
-		runner := scenario.Crane
+		scenario.TgtAppNonAdmin.Namespace = tgtNamespace
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+
+		srcApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+
+		By("Grant namespace admin permissions to the nonadmin user on both namespaces")
+		kubectlSrc, cleanupSrc, err := SetupActiveNamespaceAdmin(scenario.KubectlSrc, scenario.KubectlSrcNonAdmin.Context, srcNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		kubectlTgt, cleanupTgt, err := SetupActiveNamespaceAdmin(scenario.KubectlTgt, scenario.KubectlTgtNonAdmin.Context, tgtNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupTgt)
+		DeferCleanup(cleanupSrc)
 
 		paths, err := NewScenarioPaths("crane-export-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -44,6 +57,8 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
 		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
 
+		var destSCName string
+		var cleanupDestSC func() error
 		DeferCleanup(func() {
 			By("Cleanup source and target resources")
 			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
@@ -51,13 +66,15 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 			}
 			By("Delete source and target namespaces")
 			for _, ns := range []string{srcNamespace, tgtNamespace} {
-				if _, err := kubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+				if _, err := scenario.KubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
 					log.Printf("cleanup: %v", err)
 				}
 			}
-			By("Delete cloned destination StorageClass")
-			if err := DeleteStorageClass(srcApp.Context, destSCName); err != nil {
-				log.Printf("cleanup: %v", err)
+			By("Cleanup destination StorageClass if this test created one")
+			if cleanupDestSC != nil {
+				if err := cleanupDestSC(); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
 			}
 		})
 
@@ -65,16 +82,18 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 		log.Printf("Preparing source app %s in namespace %s", srcApp.Name, srcApp.Namespace)
 		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
 
-		By("Resolve source StorageClass and clone a distinct destination class")
+		By("Resolve source StorageClass and choose a distinct destination class")
 		srcPVC, err := GetPVC(srcApp.Context, srcNamespace, pvcName)
 		Expect(err).NotTo(HaveOccurred())
-		srcSC, err := ResolvePVCStorageClass(srcApp.Context, *srcPVC)
+		srcSC, err := ResolvePVCStorageClass(scenario.SrcApp.Context, *srcPVC)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(srcSC).NotTo(BeEmpty(), "source PVC %s/%s must have a StorageClass", srcNamespace, pvcName)
 		log.Printf("Source PVC %s/%s StorageClass=%s", srcNamespace, pvcName, srcSC)
 
-		Expect(CloneStorageClass(srcApp.Context, srcSC, destSCName)).NotTo(HaveOccurred())
+		destSCName, cleanupDestSC, err = PrepareDestinationStorageClass(scenario.SrcApp.Context, srcSC, fallbackDestSCName)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(destSCName).NotTo(Equal(srcSC))
+		log.Printf("Using destination StorageClass=%s", destSCName)
 
 		By("Scale down source MongoDB so the RWO PVC is unmounted")
 		Expect(kubectlSrc.ScaleDeploymentIfPresent(srcNamespace, appName, 0)).NotTo(HaveOccurred())
@@ -86,10 +105,8 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 		runner.WorkDir = paths.TempDir
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Create destination namespace and transfer PVC onto the cloned StorageClass")
-		Expect(kubectlTgt.CreateNamespace(tgtNamespace)).NotTo(HaveOccurred())
-
-		nodeIP, err := GetClusterNodeIP(srcApp.Context)
+		By("Transfer PVC onto the destination StorageClass")
+		nodeIP, err := GetClusterNodeIP(scenario.SrcApp.Context)
 		Expect(err).NotTo(HaveOccurred())
 		opts := TransferPVCOptions{
 			SourceContext:    srcApp.Context,
@@ -112,7 +129,7 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 			"destination PVC StorageClass should be %s", destSCName)
 
 		By("Apply remapped manifests to destination namespace")
-		Expect(ApplyOutputToTargetWithNamespaceRemap(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
+		Expect(ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
 
 		By("Scale destination MongoDB and validate data")
 		Expect(kubectlTgt.ScaleDeployment(tgtNamespace, appName, 1)).NotTo(HaveOccurred())

--- a/hack/setup-minikube-same-network.sh
+++ b/hack/setup-minikube-same-network.sh
@@ -8,7 +8,7 @@ set -x
 # 3) start src on that network, read src IP
 # 4) re-start src with --static-ip=<src-ip>
 # 5) start tgt with --static-ip=<src-ip last-octet + 1>
-# 6) setup ingress on tgt (ssl passthrough + hostPort 443)
+# 6) setup ingress on src/tgt (ssl passthrough + hostPort 443)
 #
 # Config:
 #   NETWORK_NAME       default: minikube-mc
@@ -163,6 +163,36 @@ enable_olm() {
   fi
 }
 
+setup_ingress() {
+  local profile="$1"
+
+  log "Setting up ingress on profile: ${profile}"
+  minikube addons enable ingress -p "$profile"
+  kubectl wait -n ingress-nginx --for=condition=available deployment/ingress-nginx-controller \
+    --timeout="$INGRESS_WAIT" --context="$profile"
+
+  local controller_args=""
+  controller_args="$(kubectl get deployment ingress-nginx-controller -n ingress-nginx --context="$profile" -o jsonpath='{.spec.template.spec.containers[0].args}')"
+  if [[ "$controller_args" != *"--enable-ssl-passthrough"* ]]; then
+    log "Enabling SSL passthrough on profile: ${profile}"
+    kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$profile" --type='json' \
+      -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'
+  fi
+
+  local https_hostport=""
+  https_hostport="$(kubectl get deployment ingress-nginx-controller -n ingress-nginx --context="$profile" -o jsonpath='{.spec.template.spec.containers[0].ports[?(@.containerPort==443)].hostPort}')"
+  if [[ "$https_hostport" != "443" ]]; then
+    log "Setting hostPort 443 on profile: ${profile}"
+    if ! kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$profile" --type='json' \
+      -p='[{"op":"add","path":"/spec/template/spec/containers/0/ports/1/hostPort","value":443}]' >/dev/null 2>&1; then
+      kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$profile" --type='json' \
+        -p='[{"op":"add","path":"/spec/template/spec/containers/0/ports/0/hostPort","value":443}]'
+    fi
+  fi
+
+  kubectl rollout status deployment/ingress-nginx-controller -n ingress-nginx --context="$profile" --timeout="$INGRESS_WAIT"
+}
+
 require_cmd docker
 require_cmd minikube
 require_cmd kubectl
@@ -257,29 +287,10 @@ else
   log "Skipping user creation (CREATE_USERS=${CREATE_USERS})"
 fi
 
-log "Setting up ingress on target profile: ${TGT_PROFILE}"
-minikube addons enable ingress -p "$TGT_PROFILE"
-kubectl wait -n ingress-nginx --for=condition=available deployment/ingress-nginx-controller \
-  --timeout="$INGRESS_WAIT" --context="$TGT_PROFILE"
-
-controller_args="$(kubectl get deployment ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" -o jsonpath='{.spec.template.spec.containers[0].args}')"
-if [[ "$controller_args" != *"--enable-ssl-passthrough"* ]]; then
-  log "Enabling SSL passthrough"
-  kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" --type='json' \
-    -p='[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--enable-ssl-passthrough"}]'
+setup_ingress "$SRC_PROFILE"
+if [[ "$TGT_PROFILE" != "$SRC_PROFILE" ]]; then
+  setup_ingress "$TGT_PROFILE"
 fi
-
-https_hostport="$(kubectl get deployment ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" -o jsonpath='{.spec.template.spec.containers[0].ports[?(@.containerPort==443)].hostPort}')"
-if [[ "$https_hostport" != "443" ]]; then
-  log "Setting hostPort 443"
-  if ! kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" --type='json' \
-    -p='[{"op":"add","path":"/spec/template/spec/containers/0/ports/1/hostPort","value":443}]' >/dev/null 2>&1; then
-    kubectl patch deployment ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" --type='json' \
-      -p='[{"op":"add","path":"/spec/template/spec/containers/0/ports/0/hostPort","value":443}]'
-  fi
-fi
-
-kubectl rollout status deployment/ingress-nginx-controller -n ingress-nginx --context="$TGT_PROFILE" --timeout="$INGRESS_WAIT"
 
 log "Done."
 log "Profiles: ${SRC_PROFILE}(${actual_src_ip}) ${TGT_PROFILE}(${actual_tgt_ip})"


### PR DESCRIPTION
…conversion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for transferring persistent volumes to a specified destination storage class.
  * Added automatic storage-class discovery, resolution, cloning, and cleanup.
  * Added resource discovery by label across common Kubernetes resources, including OpenShift routes.
  * Added namespace-remapped application of transferred resources in non-admin scenarios.
  * Improved same-cluster migration support and configured ingress across both environments.

* **Tests**
  * Added end-to-end coverage for same-cluster persistent-volume conversion and transfer.
  * Added validation for storage-class defaults and migrated workloads, namespaces, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->