### PR TITLE
:bug: Update golden manifest for redis

### DIFF
--- a/e2e-tests/golden-manifests-ocp/redis/export/resources/redis/Deployment_apps_v1_redis_redis.yaml
+++ b/e2e-tests/golden-manifests-ocp/redis/export/resources/redis/Deployment_apps_v1_redis_redis.yaml
@@ -127,7 +127,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests-ocp/redis/export/resources/redis/ReplicaSet_apps_v1_redis_redis-6b9f4c765d.yaml
+++ b/e2e-tests/golden-manifests-ocp/redis/export/resources/redis/ReplicaSet_apps_v1_redis_redis-6b9f4c765d.yaml
@@ -114,7 +114,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests-ocp/redis/output/output.yaml
+++ b/e2e-tests/golden-manifests-ocp/redis/output/output.yaml
@@ -60,7 +60,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests-ocp/redis/output/resources/redis/Deployment_apps_v1_redis_redis.yaml
+++ b/e2e-tests/golden-manifests-ocp/redis/output/resources/redis/Deployment_apps_v1_redis_redis.yaml
@@ -29,7 +29,7 @@ spec:
             - redis-server
             - --requirepass
             - PASSWORD
-          image: redis:latest
+          image: docker.io/library/redis:latest
           imagePullPolicy: Always
           name: redis
           ports:

--- a/e2e-tests/golden-manifests/redis/export/resources/redis/Deployment_apps_v1_redis_redis.yaml
+++ b/e2e-tests/golden-manifests/redis/export/resources/redis/Deployment_apps_v1_redis_redis.yaml
@@ -133,7 +133,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests/redis/export/resources/redis/ReplicaSet_apps_v1_redis_redis-fd76f5747.yaml
+++ b/e2e-tests/golden-manifests/redis/export/resources/redis/ReplicaSet_apps_v1_redis_redis-fd76f5747.yaml
@@ -118,7 +118,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests/redis/output/output.yaml
+++ b/e2e-tests/golden-manifests/redis/output/output.yaml
@@ -60,7 +60,7 @@ spec:
         - redis-server
         - --requirepass
         - PASSWORD
-        image: redis:latest
+        image: docker.io/library/redis:latest
         imagePullPolicy: Always
         name: redis
         ports:

--- a/e2e-tests/golden-manifests/redis/output/resources/redis/Deployment_apps_v1_redis_redis.yaml
+++ b/e2e-tests/golden-manifests/redis/output/resources/redis/Deployment_apps_v1_redis_redis.yaml
@@ -29,7 +29,7 @@ spec:
             - redis-server
             - --requirepass
             - PASSWORD
-          image: redis:latest
+          image: docker.io/library/redis:latest
           imagePullPolicy: Always
           name: redis
           ports:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Redis container image references to use the fully qualified `docker.io/library/redis:latest` image.
  - Applied the change consistently across deployment and replica set configurations.

- **Tests**
  - Updated expected Kubernetes manifests to reflect the standardized Redis image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->