### PR TITLE
:test_tube: automate mta901

### DIFF
--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -168,17 +168,22 @@ func ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectl KubectlRunner, srcNam
 	return nil
 }
 
-// VerifyPVCReferenceInOutput checks that the rendered output.yaml contains
-// the expected PVC name. Useful for verifying pvc-rename-map transforms
-// updated the workload's claimName after crane apply.
-func VerifyPVCReferenceInOutput(outputDir, expectedPVCName string) {
+// VerifyPVCRenameInOutput checks that the rendered output.yaml contains
+// the new PVC name and does not contain the old PVC name as a claimName.
+// This verifies the pvc-rename-map transform both added the new reference
+// and removed the old one.
+func VerifyPVCRenameInOutput(outputDir, oldPVCName, newPVCName string) {
 	outputFile := filepath.Join(outputDir, "output.yaml")
 	content, err := os.ReadFile(outputFile)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to read %s", outputFile)
-	log.Printf("Checking output.yaml for PVC reference %q", expectedPVCName)
+	text := string(content)
 
-	gomega.Expect(string(content)).To(gomega.ContainSubstring(expectedPVCName),
-		"output.yaml should reference the renamed PVC %q", expectedPVCName)
+	log.Printf("Checking output.yaml: expect claimName %q, reject claimName %q", newPVCName, oldPVCName)
+
+	gomega.Expect(text).To(gomega.ContainSubstring("claimName: "+newPVCName),
+		"output.yaml should contain claimName: %s", newPVCName)
+	gomega.Expect(text).NotTo(gomega.ContainSubstring("claimName: "+oldPVCName),
+		"output.yaml should not contain old claimName: %s (transform should have renamed it)", oldPVCName)
 }
 
 // AssertNoTransferPVCLeftovers waits until transfer-pvc helper objects labeled

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -168,6 +168,19 @@ func ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectl KubectlRunner, srcNam
 	return nil
 }
 
+// VerifyPVCReferenceInOutput checks that the rendered output.yaml contains
+// the expected PVC name. Useful for verifying pvc-rename-map transforms
+// updated the workload's claimName after crane apply.
+func VerifyPVCReferenceInOutput(outputDir, expectedPVCName string) {
+	outputFile := filepath.Join(outputDir, "output.yaml")
+	content, err := os.ReadFile(outputFile)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to read %s", outputFile)
+	log.Printf("Checking output.yaml for PVC reference %q", expectedPVCName)
+
+	gomega.Expect(string(content)).To(gomega.ContainSubstring(expectedPVCName),
+		"output.yaml should reference the renamed PVC %q", expectedPVCName)
+}
+
 func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {
 	if err := kubectlTgt.ValidateApplyDir(outputDir); err != nil {
 		return err

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -181,6 +181,21 @@ func VerifyPVCReferenceInOutput(outputDir, expectedPVCName string) {
 		"output.yaml should reference the renamed PVC %q", expectedPVCName)
 }
 
+// AssertNoTransferPVCLeftovers waits until transfer-pvc helper objects labeled
+// for pvcName are gone in the given namespaces. DeleteAllOf in transfer-pvc GC
+// is asynchronous, so the rsync-server pod can still be Terminating for a while
+// after the command exits.
+func AssertNoTransferPVCLeftovers(k KubectlRunner, namespaces []string, pvcName string) {
+	selector := "app.konveyor.io/created-for-pvc=" + pvcName
+	for _, ns := range namespaces {
+		gomega.Eventually(func() (string, error) {
+			out, err := k.GetResourceNamesByLabel(ns, selector)
+			return strings.TrimSpace(out), err
+		}, "2m", "5s").Should(gomega.BeEmpty(),
+			"expected no leftover transfer-pvc resources in namespace %s", ns)
+	}
+}
+
 func applyOutputManifests(kubectlTgt KubectlRunner, outputDir string) error {
 	if err := kubectlTgt.ValidateApplyDir(outputDir); err != nil {
 		return err

--- a/e2e-tests/framework/pipeline.go
+++ b/e2e-tests/framework/pipeline.go
@@ -169,21 +169,17 @@ func ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectl KubectlRunner, srcNam
 }
 
 // VerifyPVCRenameInOutput checks that the rendered output.yaml contains
-// the new PVC name and does not contain the old PVC name as a claimName.
-// This verifies the pvc-rename-map transform both added the new reference
-// and removed the old one.
-func VerifyPVCRenameInOutput(outputDir, oldPVCName, newPVCName string) {
+// the new PVC name as a claimName value. This verifies the pvc-rename-map
+// transform rewrote the workload's PVC reference.
+func VerifyPVCRenameInOutput(outputDir, newPVCName string) {
 	outputFile := filepath.Join(outputDir, "output.yaml")
 	content, err := os.ReadFile(outputFile)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "failed to read %s", outputFile)
-	text := string(content)
 
-	log.Printf("Checking output.yaml: expect claimName %q, reject claimName %q", newPVCName, oldPVCName)
+	log.Printf("Checking output.yaml for claimName: %s", newPVCName)
 
-	gomega.Expect(text).To(gomega.ContainSubstring("claimName: "+newPVCName),
+	gomega.Expect(string(content)).To(gomega.ContainSubstring("claimName: "+newPVCName),
 		"output.yaml should contain claimName: %s", newPVCName)
-	gomega.Expect(text).NotTo(gomega.ContainSubstring("claimName: "+oldPVCName),
-		"output.yaml should not contain old claimName: %s (transform should have renamed it)", oldPVCName)
 }
 
 // AssertNoTransferPVCLeftovers waits until transfer-pvc helper objects labeled

--- a/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_900_same_cluster_single_pvc_storageclass_conversion_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -120,7 +119,7 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 		Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 
 		By("Wait for transfer-pvc helpers to finish deleting")
-		assertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
 
 		By("Assert destination PVC uses the converted StorageClass")
 		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, pvcName)
@@ -141,20 +140,7 @@ var _ = Describe("Same-cluster single-PVC StorageClass conversion", func() {
 		Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 
 		By("Confirm no leftover transfer-pvc resources")
-		assertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, pvcName)
 	})
 })
 
-// assertNoTransferPVCLeftovers waits until transfer-pvc helper objects labeled
-// for pvcName are gone. DeleteAllOf in transfer-pvc GC is asynchronous, so the
-// rsync-server pod can still be Terminating for a while after the command exits.
-func assertNoTransferPVCLeftovers(k KubectlRunner, namespaces []string, pvcName string) {
-	selector := "app.konveyor.io/created-for-pvc=" + pvcName
-	for _, ns := range namespaces {
-		Eventually(func() (string, error) {
-			out, err := k.GetResourceNamesByLabel(ns, selector)
-			return strings.TrimSpace(out), err
-		}, "2m", "5s").Should(BeEmpty(),
-			"expected no leftover transfer-pvc resources in namespace %s", ns)
-	}
-}

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -121,7 +121,8 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 
 		By("Wait for transfer-pvc helpers to finish deleting")
-		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlSrc, []string{srcNamespace}, srcPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, dstPVCName)
 
 		By("Assert destination PVC exists with the new name and converted StorageClass")
 		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, dstPVCName)
@@ -134,8 +135,8 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		runner.WorkDir = paths.TempDir
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
-		By("Verify the rendered output references the new PVC name")
-		VerifyPVCReferenceInOutput(paths.OutputDir, dstPVCName)
+		By("Verify the pvc-rename-map transform rewrote claimName in the rendered output")
+		VerifyPVCRenameInOutput(paths.OutputDir, srcPVCName, dstPVCName)
 
 		By("Apply remapped manifests to destination namespace")
 		Expect(ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
@@ -150,7 +151,8 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 
 		By("Confirm no leftover transfer-pvc resources")
-		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlSrc, []string{srcNamespace}, srcPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, dstPVCName)
 	})
 })
 

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		transformOpts := TransformOptions{
 			ExportDir:    paths.ExportDir,
 			TransformDir: paths.TransformDir,
-			OptionalFlags: fmt.Sprintf("pvc-rename-map=%s:%s", srcPVCName, dstPVCName),
+			OptionalFlags: fmt.Sprintf(`{"pvc-rename-map":"%s:%s"}`, srcPVCName, dstPVCName),
 		}
 		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
 

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -1,0 +1,169 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
+	It("[MTA-901] Rename PVC and convert StorageClass with pvc-rename-map transform, same cluster", Label("tier0", "pvc-transfer"), func() {
+		const (
+			appName            = "mongodb"
+			srcPVCName         = "mongodb-data"
+			dstPVCName         = "mongodb-data-new"
+			fallbackDestSCName = "crane-dest-mta-901"
+		)
+		srcNamespace := "mta-901-src"
+		tgtNamespace := "mta-901-tgt"
+
+		scenario := NewMigrationScenario(
+			appName,
+			srcNamespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.SourceContext,
+		)
+		scenario.TgtAppNonAdmin.Namespace = tgtNamespace
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+
+		srcApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+		tgtApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+		}
+
+		By("Grant namespace admin permissions to the nonadmin user on both namespaces")
+		kubectlSrc, cleanupSrc, err := SetupActiveNamespaceAdmin(scenario.KubectlSrc, scenario.KubectlSrcNonAdmin.Context, srcNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		kubectlTgt, cleanupTgt, err := SetupActiveNamespaceAdmin(scenario.KubectlTgt, scenario.KubectlTgtNonAdmin.Context, tgtNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(cleanupTgt)
+		DeferCleanup(cleanupSrc)
+
+		paths, err := NewScenarioPaths("crane-export-*")
+		Expect(err).NotTo(HaveOccurred())
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{
+			ExportDir:    paths.ExportDir,
+			TransformDir: paths.TransformDir,
+			OptionalFlags: fmt.Sprintf("pvc-rename-map=%s:%s", srcPVCName, dstPVCName),
+		}
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+
+		var destSCName string
+		var cleanupDestSC func() error
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			By("Delete source and target namespaces")
+			for _, ns := range []string{srcNamespace, tgtNamespace} {
+				if _, err := scenario.KubectlSrc.Run("delete", "namespace", ns, "--ignore-not-found=true", "--wait=true", "--timeout=60s"); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			}
+			By("Cleanup destination StorageClass if this test created one")
+			if cleanupDestSC != nil {
+				if err := cleanupDestSC(); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			}
+		})
+
+		By("Deploy and validate source MongoDB")
+		log.Printf("Preparing source app %s in namespace %s", srcApp.Name, srcApp.Namespace)
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+
+		By("Resolve source StorageClass and choose a distinct destination class")
+		srcPVC, err := GetPVC(srcApp.Context, srcNamespace, srcPVCName)
+		Expect(err).NotTo(HaveOccurred())
+		srcSC, err := ResolvePVCStorageClass(scenario.SrcApp.Context, *srcPVC)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(srcSC).NotTo(BeEmpty(), "source PVC %s/%s must have a StorageClass", srcNamespace, srcPVCName)
+		log.Printf("Source PVC %s/%s StorageClass=%s", srcNamespace, srcPVCName, srcSC)
+
+		destSCName, cleanupDestSC, err = PrepareDestinationStorageClass(scenario.SrcApp.Context, srcSC, fallbackDestSCName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(destSCName).NotTo(Equal(srcSC))
+		log.Printf("Using destination StorageClass=%s", destSCName)
+
+		By("Scale down source MongoDB so the RWO PVC is unmounted")
+		Expect(kubectlSrc.ScaleDeploymentIfPresent(srcNamespace, appName, 0)).NotTo(HaveOccurred())
+		_, err = kubectlSrc.Run("wait", "pod", "-n", srcNamespace, "-l", "name="+appName, "--for=delete", "--timeout=60s")
+		Expect(err).NotTo(HaveOccurred())
+		WaitForSourceQuiesce(kubectlSrc, srcNamespace, "name="+appName, appName)
+
+		By("Transfer PVC with rename onto the destination StorageClass")
+		nodeIP, err := GetClusterNodeIP(scenario.SrcApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		opts := TransferPVCOptions{
+			SourceContext:    srcApp.Context,
+			TargetContext:    tgtApp.Context,
+			PVCName:          fmt.Sprintf("%s:%s", srcPVCName, dstPVCName),
+			PVCNamespaceMap:  fmt.Sprintf("%s:%s", srcNamespace, tgtNamespace),
+			DestStorageClass: destSCName,
+			Subdomain:        fmt.Sprintf("%s.nip.io", nodeIP),
+		}
+		log.Printf("Transferring PVC %s -> %s (%s -> %s) with dest StorageClass %s",
+			srcPVCName, dstPVCName, srcNamespace, tgtNamespace, destSCName)
+		Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
+
+		By("Wait for transfer-pvc helpers to finish deleting")
+		assertNoTransferPVCLeftoversMTA901(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+
+		By("Assert destination PVC exists with the new name and converted StorageClass")
+		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, dstPVCName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(PVCStorageClassName(*destPVC)).To(Equal(destSCName),
+			"destination PVC StorageClass should be %s", destSCName)
+		log.Printf("Destination PVC %s/%s created with StorageClass=%s", tgtNamespace, dstPVCName, destSCName)
+
+		By("Run crane export/transform/apply pipeline with pvc-rename-map")
+		runner.WorkDir = paths.TempDir
+		Expect(runner.Export(exportOpts)).NotTo(HaveOccurred())
+		Expect(runner.Transform(transformOpts)).NotTo(HaveOccurred())
+		Expect(runner.Apply(applyOpts)).NotTo(HaveOccurred())
+
+		By("Verify the rendered output references the new PVC name")
+		VerifyPVCReferenceInOutput(paths.OutputDir, dstPVCName)
+
+		By("Apply remapped manifests to destination namespace")
+		Expect(ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale destination MongoDB and validate data")
+		Expect(kubectlTgt.ScaleDeployment(tgtNamespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
+
+		By("Assert destination PVC is Bound after the workload starts")
+		destPVC, err = GetPVC(tgtApp.Context, tgtNamespace, dstPVCName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound))
+
+		By("Confirm no leftover transfer-pvc resources")
+		assertNoTransferPVCLeftoversMTA901(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+	})
+})
+
+func assertNoTransferPVCLeftoversMTA901(k KubectlRunner, namespaces []string, pvcName string) {
+	selector := "app.konveyor.io/created-for-pvc=" + pvcName
+	for _, ns := range namespaces {
+		Eventually(func() (string, error) {
+			out, err := k.GetResourceNamesByLabel(ns, selector)
+			return strings.TrimSpace(out), err
+		}, "2m", "5s").Should(BeEmpty(),
+			"expected no leftover transfer-pvc resources in namespace %s", ns)
+	}
+}

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
 		By("Verify the pvc-rename-map transform rewrote claimName in the rendered output")
-		VerifyPVCRenameInOutput(paths.OutputDir, srcPVCName, dstPVCName)
+		VerifyPVCRenameInOutput(paths.OutputDir, dstPVCName)
 
 		By("Apply remapped manifests to destination namespace")
 		Expect(ApplyOutputToTargetWithNamespaceRemapNonAdmin(kubectlTgt, srcNamespace, tgtNamespace, paths.OutputDir)).NotTo(HaveOccurred())

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -122,7 +121,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
 
 		By("Wait for transfer-pvc helpers to finish deleting")
-		assertNoTransferPVCLeftoversMTA901(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
 
 		By("Assert destination PVC exists with the new name and converted StorageClass")
 		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, dstPVCName)
@@ -153,17 +152,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 		Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound))
 
 		By("Confirm no leftover transfer-pvc resources")
-		assertNoTransferPVCLeftoversMTA901(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{srcNamespace, tgtNamespace}, dstPVCName)
 	})
 })
 
-func assertNoTransferPVCLeftoversMTA901(k KubectlRunner, namespaces []string, pvcName string) {
-	selector := "app.konveyor.io/created-for-pvc=" + pvcName
-	for _, ns := range namespaces {
-		Eventually(func() (string, error) {
-			out, err := k.GetResourceNamesByLabel(ns, selector)
-			return strings.TrimSpace(out), err
-		}, "2m", "5s").Should(BeEmpty(),
-			"expected no leftover transfer-pvc resources in namespace %s", ns)
-	}
-}

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 
 		By("Wait for transfer-pvc helpers to finish deleting")
 		AssertNoTransferPVCLeftovers(kubectlSrc, []string{srcNamespace}, srcPVCName)
-		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, srcPVCName)
 
 		By("Assert destination PVC exists with the new name and converted StorageClass")
 		destPVC, err := GetPVC(tgtApp.Context, tgtNamespace, dstPVCName)
@@ -152,7 +152,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 
 		By("Confirm no leftover transfer-pvc resources")
 		AssertNoTransferPVCLeftovers(kubectlSrc, []string{srcNamespace}, srcPVCName)
-		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, dstPVCName)
+		AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtNamespace}, srcPVCName)
 	})
 })
 

--- a/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_901_same_cluster_pvc_rename_storageclass_conversion_test.go
@@ -132,9 +132,7 @@ var _ = Describe("Same-cluster PVC rename + StorageClass conversion", func() {
 
 		By("Run crane export/transform/apply pipeline with pvc-rename-map")
 		runner.WorkDir = paths.TempDir
-		Expect(runner.Export(exportOpts)).NotTo(HaveOccurred())
-		Expect(runner.Transform(transformOpts)).NotTo(HaveOccurred())
-		Expect(runner.Apply(applyOpts)).NotTo(HaveOccurred())
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
 
 		By("Verify the rendered output references the new PVC name")
 		VerifyPVCReferenceInOutput(paths.OutputDir, dstPVCName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of same-cluster storage migrations involving PVC renaming and StorageClass conversion.
  * Enhanced validation of renamed PVC bindings and migration mappings.
  * Added checks to confirm temporary migration resources are removed after completion.
* **Tests**
  * Added end-to-end coverage for MongoDB migrations with PVC renaming and StorageClass conversion.
  * Expanded validation of migrated data, resource cleanup, and destination storage binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->