### PR TITLE
:test_tube: [MTA-903] Convert multiple PVCs sc sequentially

### DIFF
--- a/.github/workflows/e2e-pr-tester.yaml
+++ b/.github/workflows/e2e-pr-tester.yaml
@@ -138,7 +138,7 @@ jobs:
           esac
 
   # Full suite: run tier0 and tier1 in parallel via the reusable workflow
-  # (same path as main/nightly), each with its own 60-minute timeout.
+  # (same path as main/nightly), each with its own 90-minute timeout.
   e2e-tier0:
     needs: detect-changes
     if: needs.detect-changes.outputs.run_tests == 'true' && needs.detect-changes.outputs.run_mode == 'all'

--- a/.github/workflows/reusable-e2e-tier-tests.yml
+++ b/.github/workflows/reusable-e2e-tier-tests.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   run-e2e:
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/e2e-tests/framework/test_helpers.go
+++ b/e2e-tests/framework/test_helpers.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -139,6 +140,56 @@ func GetSecretData(kubectl KubectlRunner, namespace, secretName string) (map[str
 		return nil, fmt.Errorf("failed to parse secret %s JSON: %w", secretName, err)
 	}
 	return secretObj.Data, nil
+}
+
+// MySQLAuthorsCount returns the number of rows in the authors table from a
+// running MySQL pod.
+func MySQLAuthorsCount(k KubectlRunner, namespace, podName string) (int, error) {
+	out, err := k.Run(
+		"exec", podName, "-n", namespace, "--",
+		"sh", "-c",
+		`MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -B -h 127.0.0.1 -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "SELECT COUNT(*) FROM authors;"`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		return 0, fmt.Errorf("parse authors count %q: %w", strings.TrimSpace(out), err)
+	}
+	return count, nil
+}
+
+// WaitForMySQLSocket checks whether the MySQL unix socket exists in the pod.
+func WaitForMySQLSocket(k KubectlRunner, namespace, podName string) error {
+	_, err := k.Run(
+		"exec", podName, "-n", namespace, "--",
+		"sh", "-c",
+		`test -S /var/lib/mysql/mysql.sock`,
+	)
+	return err
+}
+
+// MySQLTestDataMD5 returns the actual and expected md5 values for the seeded
+// MySQL sidecar test file.
+func MySQLTestDataMD5(k KubectlRunner, namespace, podName string) (actual string, expected string, _ error) {
+	actualOut, err := k.Run(
+		"exec", podName, "-n", namespace, "--",
+		"sh", "-c",
+		`md5sum /test-data/test1 | awk '{print $1}'`,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	expectedOut, err := k.Run(
+		"exec", podName, "-n", namespace, "--",
+		"sh", "-c",
+		`awk '{print $1}' /test-data/test1.md5`,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	return strings.TrimSpace(actualOut), strings.TrimSpace(expectedOut), nil
 }
 
 // PodVolumeMount maps a PVC to a mount path inside a VerifierPodOptions pod.

--- a/e2e-tests/tests/tier0/mta_807_data_validation_test.go
+++ b/e2e-tests/tests/tier0/mta_807_data_validation_test.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
@@ -11,51 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func mysqlAuthorsCount(k KubectlRunner, namespace, podName string) (int, error) {
-	out, err := k.Run(
-		"exec", podName, "-n", namespace, "--",
-		"sh", "-c",
-		`MYSQL_PWD="$MYSQL_PASSWORD" mysql -N -B -h 127.0.0.1 -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "SELECT COUNT(*) FROM authors;"`,
-	)
-	if err != nil {
-		return 0, err
-	}
-	count, err := strconv.Atoi(strings.TrimSpace(out))
-	if err != nil {
-		return 0, fmt.Errorf("parse authors count %q: %w", strings.TrimSpace(out), err)
-	}
-	return count, nil
-}
-
-func waitForMySQLSocket(k KubectlRunner, namespace, podName string) error {
-	_, err := k.Run(
-		"exec", podName, "-n", namespace, "--",
-		"sh", "-c",
-		`test -S /var/lib/mysql/mysql.sock`,
-	)
-	return err
-}
-
-func mysqlTestDataMD5(k KubectlRunner, namespace, podName string) (actual string, expected string, _ error) {
-	actualOut, err := k.Run(
-		"exec", podName, "-n", namespace, "--",
-		"sh", "-c",
-		`md5sum /test-data/test1 | awk '{print $1}'`,
-	)
-	if err != nil {
-		return "", "", err
-	}
-	expectedOut, err := k.Run(
-		"exec", podName, "-n", namespace, "--",
-		"sh", "-c",
-		`awk '{print $1}' /test-data/test1.md5`,
-	)
-	if err != nil {
-		return "", "", err
-	}
-	return strings.TrimSpace(actualOut), strings.TrimSpace(expectedOut), nil
-}
 
 var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 
@@ -106,11 +60,11 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 		srcPodName, err := GetPodNameByLabel(kubectlSrcNonAdmin, srcApp.Namespace, "app="+appName)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(func() error {
-			return waitForMySQLSocket(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+			return WaitForMySQLSocket(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
 		}, "2m", "5s").Should(Succeed())
-		sourceAuthorsCount, err := mysqlAuthorsCount(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+		sourceAuthorsCount, err := MySQLAuthorsCount(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
 		Expect(err).NotTo(HaveOccurred())
-		sourceMD5Actual, sourceMD5Expected, err := mysqlTestDataMD5(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+		sourceMD5Actual, sourceMD5Expected, err := MySQLTestDataMD5(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Source validation output: pod=%s authors_count=%d md5_actual=%s md5_expected=%s", srcPodName, sourceAuthorsCount, sourceMD5Actual, sourceMD5Expected)
 		Expect(sourceMD5Actual).To(Equal(sourceMD5Expected), "source test-data checksum should match its md5 file")
@@ -232,12 +186,12 @@ var _ = Describe("Data validation with indirect migration of MySQL DB", func() {
 			return nil
 		}, "2m", "10s").Should(Succeed())
 		Eventually(func() error {
-			return waitForMySQLSocket(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+			return WaitForMySQLSocket(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
 		}, "2m", "5s").Should(Succeed())
 
-		targetAuthorsCount, err := mysqlAuthorsCount(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+		targetAuthorsCount, err := MySQLAuthorsCount(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
 		Expect(err).NotTo(HaveOccurred())
-		targetMD5Actual, targetMD5Expected, err := mysqlTestDataMD5(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+		targetMD5Actual, targetMD5Expected, err := MySQLTestDataMD5(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Target validation output: pod=%s authors_count=%d md5_actual=%s md5_expected=%s", tgtPodName, targetAuthorsCount, targetMD5Actual, targetMD5Expected)
 		Expect(targetMD5Actual).To(Equal(targetMD5Expected), "target test-data checksum should match its md5 file")

--- a/e2e-tests/tests/tier0/mta_903_multi_pvc_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_903_multi_pvc_storageclass_conversion_test.go
@@ -1,0 +1,257 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cross-cluster multi-PVC StorageClass conversion", func() {
+	It("[MTA-903] Convert multiple PVCs in a namespace via sequential transfer-pvc invocations", Label("tier0", "pvc-transfer"), func() {
+		const (
+			appName            = "mysql"
+			namespace          = "mta-903-mysql"
+			fallbackDestSCName = "crane-dest-mta-903"
+		)
+
+		expectedPVCNames := []string{"mysql-data", "mysql-data1"}
+
+		scenario := NewMigrationScenario(
+			appName,
+			namespace,
+			config.K8sDeployBin,
+			config.CraneBin,
+			config.SourceContext,
+			config.TargetContext,
+		)
+		srcApp := scenario.SrcAppNonAdmin
+		tgtApp := scenario.TgtAppNonAdmin
+		runner := scenario.CraneNonAdmin
+
+		isOCP := scenario.KubectlSrc.IsOpenShift()
+		srcApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+			"has_scc":        isOCP,
+		}
+		tgtApp.ExtraVars = map[string]any{
+			"non_admin_user": "true",
+			"has_scc":        isOCP,
+		}
+
+		By("Grant namespace admin permissions to the nonadmin user on source and target")
+		kubectlSrcNonAdmin, kubectlTgtNonAdmin, cleanup, err := SetupActiveKubectlRunners(scenario, namespace)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			By("Delete test namespace on source and target")
+			for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
+				if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
+					log.Printf("cleanup: failed to delete namespace %q on context %q: %v", namespace, k.Context, err)
+				}
+			}
+		})
+		DeferCleanup(cleanup)
+
+		paths, err := NewScenarioPaths("crane-mta-903-*")
+		Expect(err).NotTo(HaveOccurred())
+		runner.WorkDir = paths.TempDir
+
+		var cleanupDestSC func() error
+		DeferCleanup(func() {
+			By("Cleanup source and target resources")
+			if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+				log.Printf("cleanup: %v", err)
+			}
+			By("Cleanup destination StorageClass if this test created one")
+			if cleanupDestSC != nil {
+				if err := cleanupDestSC(); err != nil {
+					log.Printf("cleanup: %v", err)
+				}
+			}
+		})
+
+		By("Deploy and validate source MySQL app")
+		Expect(PrepareSourceAppNoQuiesce(srcApp)).NotTo(HaveOccurred())
+
+		By("Capture source data fingerprints for comparison")
+		srcPodName, err := GetPodNameByLabel(kubectlSrcNonAdmin, srcApp.Namespace, "app="+appName)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			return WaitForMySQLSocket(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+		}, "2m", "5s").Should(Succeed())
+		sourceAuthorsCount, err := MySQLAuthorsCount(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+		Expect(err).NotTo(HaveOccurred())
+		sourceMD5Actual, sourceMD5Expected, err := MySQLTestDataMD5(kubectlSrcNonAdmin, srcApp.Namespace, srcPodName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sourceMD5Actual).To(Equal(sourceMD5Expected), "source test-data checksum should match its md5 file")
+
+		By("List MySQL PVCs and confirm the expected two claims exist")
+		pvcs, err := ListPVCs(srcApp.Namespace, "", srcApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pvcs).To(HaveLen(len(expectedPVCNames)), "expected exactly %d PVCs in namespace %q", len(expectedPVCNames), srcApp.Namespace)
+		expectPVCNames(pvcs, expectedPVCNames)
+
+		By("Resolve the source StorageClass and choose a distinct destination class on target")
+		var sourceSC string
+		for i, pvcName := range expectedPVCNames {
+			srcPVC, err := GetPVC(srcApp.Context, srcApp.Namespace, pvcName)
+			Expect(err).NotTo(HaveOccurred())
+			resolvedSC, err := ResolvePVCStorageClass(scenario.KubectlSrc.Context, *srcPVC)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolvedSC).NotTo(BeEmpty(), "source PVC %s/%s must have a StorageClass", srcApp.Namespace, pvcName)
+			if i == 0 {
+				sourceSC = resolvedSC
+				continue
+			}
+			Expect(resolvedSC).To(Equal(sourceSC),
+				"expected all source PVCs to use the same StorageClass before conversion")
+		}
+
+		var destSCName string
+		if scenario.KubectlTgt.IsOpenShift() {
+			destSCName, cleanupDestSC, err = PrepareDestinationStorageClass(scenario.KubectlTgt.Context, sourceSC, fallbackDestSCName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(destSCName).NotTo(Equal(sourceSC))
+		} else {
+			targetDefaultSC, err := DefaultStorageClassName(scenario.KubectlTgt.Context)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(targetDefaultSC).NotTo(BeEmpty(), "target cluster must expose a default StorageClass for fallback cloning")
+
+			created, err := CloneStorageClass(scenario.KubectlTgt.Context, targetDefaultSC, fallbackDestSCName)
+			Expect(err).NotTo(HaveOccurred())
+			destSCName = fallbackDestSCName
+			if created {
+				cleanupDestSC = func() error {
+					return DeleteStorageClass(scenario.KubectlTgt.Context, fallbackDestSCName)
+				}
+			} else {
+				cleanupDestSC = func() error { return nil }
+			}
+		}
+
+		By("Quiesce the source MySQL deployment before export and transfer")
+		Expect(kubectlSrcNonAdmin.ScaleDeploymentIfPresent(srcApp.Namespace, srcApp.Name, 0)).NotTo(HaveOccurred())
+		Eventually(func() (string, error) {
+			out, err := kubectlSrcNonAdmin.Run(
+				"get", "pods",
+				"--namespace", namespace,
+				"-l", "app="+appName,
+				"-o", "name",
+			)
+			if err != nil {
+				return "", err
+			}
+			return strings.TrimSpace(out), nil
+		}, "90s", "3s").Should(BeEmpty())
+
+		By("Run crane export/transform/apply pipeline")
+		exportOpts := ExportOptions{Namespace: srcApp.Namespace, ExportDir: paths.ExportDir}
+		transformOpts := TransformOptions{ExportDir: paths.ExportDir, TransformDir: paths.TransformDir}
+		applyOpts := ApplyOptions{TransformDir: paths.TransformDir, OutputDir: paths.OutputDir}
+		Expect(RunCranePipelineWithChecks(runner, exportOpts, transformOpts, applyOpts)).NotTo(HaveOccurred())
+
+		By("Transfer each MySQL PVC sequentially onto the destination StorageClass")
+		tgtIP, err := GetClusterNodeIP(scenario.KubectlTgt.Context)
+		Expect(err).NotTo(HaveOccurred())
+		for _, pvcName := range expectedPVCNames {
+			opts := TransferPVCOptions{
+				SourceContext:    srcApp.Context,
+				TargetContext:    tgtApp.Context,
+				PVCName:          pvcName,
+				PVCNamespaceMap:  fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
+				DestStorageClass: destSCName,
+				Subdomain:        fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
+			}
+			log.Printf("Transferring PVC %s to namespace %s on target cluster with StorageClass=%s", pvcName, tgtApp.Namespace, destSCName)
+			Expect(runner.TransferPVC(opts)).NotTo(HaveOccurred())
+			AssertNoTransferPVCLeftovers(kubectlSrcNonAdmin, []string{srcApp.Namespace}, pvcName)
+			AssertNoTransferPVCLeftovers(kubectlTgtNonAdmin, []string{tgtApp.Namespace}, pvcName)
+		}
+
+		By("Verify target PVCs exist and use the converted StorageClass")
+		tgtPVCs, err := ListPVCs(tgtApp.Namespace, "", tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tgtPVCs).To(HaveLen(len(expectedPVCNames)), "expected exactly %d PVCs in target namespace %q", len(expectedPVCNames), tgtApp.Namespace)
+		Expect(VerifyPVCsExistByName(pvcs, tgtPVCs)).NotTo(HaveOccurred())
+		for _, pvcName := range expectedPVCNames {
+			destPVC, err := GetPVC(tgtApp.Context, tgtApp.Namespace, pvcName)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(PVCStorageClassName(*destPVC)).To(Equal(destSCName),
+				"destination PVC %s/%s StorageClass should be %s", tgtApp.Namespace, pvcName, destSCName)
+			Expect(destPVC.Status.Phase).To(Equal(corev1.ClaimBound),
+				"destination PVC %s/%s should be Bound after transfer", tgtApp.Namespace, pvcName)
+			Expect(VerifyPVCSchedulable(scenario.KubectlTgt.Context, tgtApp.Namespace, pvcName)).NotTo(HaveOccurred())
+		}
+
+		By("Verify each transferred PVC contains data before the workload starts")
+		Expect(VerifyPVCHasData(kubectlTgtNonAdmin, tgtApp.Namespace, "mysql-data", "/var/lib/mysql")).NotTo(HaveOccurred())
+		Expect(VerifyPVCHasData(kubectlTgtNonAdmin, tgtApp.Namespace, "mysql-data1", "/test-data")).NotTo(HaveOccurred())
+
+		By("Apply rendered manifests to target")
+		Expect(ApplyOutputToTargetNonAdmin(kubectlTgtNonAdmin, paths.OutputDir)).NotTo(HaveOccurred())
+
+		By("Scale the target MySQL deployment and validate the app")
+		Expect(kubectlTgtNonAdmin.ScaleDeployment(namespace, appName, 1)).NotTo(HaveOccurred())
+		Eventually(tgtApp.Validate, "5m", "10s").Should(Succeed())
+
+		var tgtPodName string
+		Eventually(func() error {
+			podName, err := GetPodNameByLabel(kubectlTgtNonAdmin, tgtApp.Namespace, "app="+appName)
+			if err != nil {
+				return err
+			}
+			tgtPodName = podName
+			out, err := kubectlTgtNonAdmin.Run(
+				"get", "pod", tgtPodName,
+				"-n", tgtApp.Namespace,
+				"-o", "jsonpath={.status.containerStatuses[0].ready}",
+			)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(out) != "true" {
+				return fmt.Errorf("pod %s is not ready yet", tgtPodName)
+			}
+			return nil
+		}, "2m", "10s").Should(Succeed())
+		Eventually(func() error {
+			return WaitForMySQLSocket(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+		}, "2m", "5s").Should(Succeed())
+
+		By("Verify both migrated MySQL volumes contain the correct, uncontaminated data")
+		targetAuthorsCount, err := MySQLAuthorsCount(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+		Expect(err).NotTo(HaveOccurred())
+		targetMD5Actual, targetMD5Expected, err := MySQLTestDataMD5(kubectlTgtNonAdmin, tgtApp.Namespace, tgtPodName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(targetMD5Actual).To(Equal(targetMD5Expected), "target test-data checksum should match its md5 file")
+		Expect(targetAuthorsCount).To(Equal(sourceAuthorsCount), "authors count should match between source and target")
+		Expect(targetMD5Actual).To(Equal(sourceMD5Actual), "test-data md5 should match between source and target")
+
+		By("Confirm no leftover transfer-pvc resources remain for either PVC")
+		for _, pvcName := range expectedPVCNames {
+			AssertNoTransferPVCLeftovers(kubectlSrcNonAdmin, []string{srcApp.Namespace}, pvcName)
+			AssertNoTransferPVCLeftovers(kubectlTgtNonAdmin, []string{tgtApp.Namespace}, pvcName)
+		}
+	})
+})
+
+func expectPVCNames(pvcs []corev1.PersistentVolumeClaim, expectedNames []string) {
+	GinkgoHelper()
+
+	actualNames := make(map[string]bool, len(pvcs))
+	for _, pvc := range pvcs {
+		actualNames[pvc.Name] = true
+	}
+
+	for _, expectedName := range expectedNames {
+		Expect(actualNames).To(HaveKey(expectedName),
+			"expected PVC %q to exist in the MySQL app PVC set", expectedName)
+	}
+}

--- a/e2e-tests/tests/tier0/mta_903_multi_pvc_storageclass_conversion_test.go
+++ b/e2e-tests/tests/tier0/mta_903_multi_pvc_storageclass_conversion_test.go
@@ -35,14 +35,15 @@ var _ = Describe("Cross-cluster multi-PVC StorageClass conversion", func() {
 		tgtApp := scenario.TgtAppNonAdmin
 		runner := scenario.CraneNonAdmin
 
-		isOCP := scenario.KubectlSrc.IsOpenShift()
+		srcIsOCP := scenario.KubectlSrc.IsOpenShift()
+		tgtIsOCP := scenario.KubectlTgt.IsOpenShift()
 		srcApp.ExtraVars = map[string]any{
 			"non_admin_user": "true",
-			"has_scc":        isOCP,
+			"has_scc":        srcIsOCP,
 		}
 		tgtApp.ExtraVars = map[string]any{
 			"non_admin_user": "true",
-			"has_scc":        isOCP,
+			"has_scc":        tgtIsOCP,
 		}
 
 		By("Grant namespace admin permissions to the nonadmin user on source and target")
@@ -115,7 +116,7 @@ var _ = Describe("Cross-cluster multi-PVC StorageClass conversion", func() {
 		}
 
 		var destSCName string
-		if scenario.KubectlTgt.IsOpenShift() {
+		if tgtIsOCP {
 			destSCName, cleanupDestSC, err = PrepareDestinationStorageClass(scenario.KubectlTgt.Context, sourceSC, fallbackDestSCName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(destSCName).NotTo(Equal(sourceSC))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for converting multiple MySQL persistent volumes across clusters to a destination StorageClass.
  * Added validation that migrated volumes bind correctly and retain application data, including record counts and seeded file integrity.
  * Added checks for sequential volume transfers and cleanup of temporary transfer resources.
  * Added coverage for destination StorageClass handling across supported cluster environments.

* **Chores**
  * Extended full end-to-end test job timeouts from 60 to 90 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->