### PR TITLE
:warning: Deprecate convert subcommand

### DIFF
--- a/cmd/convert/convert.go
+++ b/cmd/convert/convert.go
@@ -39,8 +39,9 @@ func NewConvertOptions(streams genericclioptions.IOStreams) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "convert",
-		Short: "Convert a deprecated resource to its replacement",
+		Use:        "convert",
+		Short:      "Convert a deprecated resource to its replacement",
+		Deprecated: "it has been replaced by the crane-plugin-buildconfig-to-shipwright plugin (https://github.com/migtools/crane-plugin-buildconfig-to-shipwright). Use it via `crane transform` instead.",
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := t.Complete(c, args); err != nil {
 				return err


### PR DESCRIPTION
Deprecating `crane convert`, that was replaced with a plugin https://github.com/migtools/crane-plugin-buildconfig-to-shipwright. The convert-related code might be deleted in following release, but even **with this PR merged, it still will work just with deprecation warning**.

### New implementation example

Migrating a namespace with a Dockerfile-based BuildConfig from OpenShift to a Shipwright-enabled cluster:

```bash
# Export from source cluster
crane export -n myapp

# Transform — OpenShift plugin strips OCP-specific resources,
# BuildConfig plugin converts builds to Shipwright
crane transform BuildConfigPlugin \
  --plugin-dir ./plugins \
  --optional-flags "registry-mapping=image-registry.openshift-image-registry.svc:5000=quay.io/myorg"

# Review generated Shipwright Builds
cat ./transform/resources/Build_shipwright.io_v1beta1_myapp_*.yaml

# Apply to target cluster (Shipwright + Tekton must be installed)
crane apply

kubectl apply -f ./output/resources/
```

Related to https://github.com/migtools/crane/issues/367

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecation**
  * The `convert` command is now deprecated.
  * Use the `crane-plugin-buildconfig-to-shipwright` plugin as the recommended replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->