### PR TITLE
:bug: Initialize controller-runtime logger in transfer-pvc, tunnel-ap…

### DIFF
--- a/cmd/convert/convert.go
+++ b/cmd/convert/convert.go
@@ -1,6 +1,7 @@
 package convert
 
 import (
+	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/konveyor/crane-lib/convert"
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/sirupsen/logrus"
@@ -9,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -83,6 +85,9 @@ func (t *ConvertOptions) Run() error {
 }
 
 func (t *ConvertOptions) run() error {
+	ctrlLogger := logrus.New()
+	logger := logrusr.New(ctrlLogger)
+	ctrllog.SetLogger(logger)
 	srcClient, err := t.getClientFromContext()
 	if err != nil {
 		return err

--- a/cmd/convert/convert.go
+++ b/cmd/convert/convert.go
@@ -1,16 +1,15 @@
 package convert
 
 import (
-	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/konveyor/crane-lib/convert"
 	"github.com/konveyor/crane/internal/flags"
+	crlog "github.com/konveyor/crane/internal/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
@@ -85,9 +84,7 @@ func (t *ConvertOptions) Run() error {
 }
 
 func (t *ConvertOptions) run() error {
-	ctrlLogger := logrus.New()
-	logger := logrusr.New(ctrlLogger)
-	ctrllog.SetLogger(logger)
+	crlog.InitControllerRuntimeLogger("")
 	srcClient, err := t.getClientFromContext()
 	if err != nil {
 		return err

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,12 +24,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konveyor/crane-lib/state_transfer/transfer/indirect"
 )
 
 func (t *TransferPVCCommand) runIndirect() error {
 	log := t.log
+	ctrlLogger := logrus.New()
+	logger := logrusr.New(ctrlLogger).WithName("transfer-pvc")
+	ctrllog.SetLogger(logger)
 	log.Infof("Starting indirect PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
 
 	fmt.Fprintf(os.Stderr, "\ncrane transfer-pvc (indirect via cloud storage)\n")

--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	logrusr "github.com/bombsimon/logrusr/v3"
+	crlog "github.com/konveyor/crane/internal/log"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,16 +24,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konveyor/crane-lib/state_transfer/transfer/indirect"
 )
 
 func (t *TransferPVCCommand) runIndirect() error {
 	log := t.log
-	ctrlLogger := logrus.New()
-	logger := logrusr.New(ctrlLogger).WithName("transfer-pvc")
-	ctrllog.SetLogger(logger)
+	crlog.InitControllerRuntimeLogger("transfer-pvc")
 	log.Infof("Starting indirect PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
 
 	fmt.Fprintf(os.Stderr, "\ncrane transfer-pvc (indirect via cloud storage)\n")

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konveyor/crane/internal/cli"
 	"github.com/konveyor/crane/internal/flags"
@@ -359,6 +360,7 @@ func (t *TransferPVCCommand) run() (retErr error) {
 	log.Infof("Starting PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
 	ctrlLogger := logrus.New()
 	logger := logrusr.New(ctrlLogger).WithName("transfer-pvc")
+	ctrllog.SetLogger(logger)
 
 	totalPhases := 7
 	if t.isIntraClusterSameNamespace() {

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -34,10 +33,10 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/konveyor/crane/internal/cli"
 	"github.com/konveyor/crane/internal/flags"
+	crlog "github.com/konveyor/crane/internal/log"
 
 	"github.com/migtools/pvc-transfer/endpoint"
 	ingressendpoint "github.com/migtools/pvc-transfer/endpoint/ingress"
@@ -358,9 +357,7 @@ func (t *TransferPVCCommand) getRestConfigFromContext(ctx string) (*rest.Config,
 func (t *TransferPVCCommand) run() (retErr error) {
 	log := t.log
 	log.Infof("Starting PVC transfer: %s/%s -> %s/%s", t.PVC.Namespace.source, t.PVC.Name.source, t.PVC.Namespace.destination, t.PVC.Name.destination)
-	ctrlLogger := logrus.New()
-	logger := logrusr.New(ctrlLogger).WithName("transfer-pvc")
-	ctrllog.SetLogger(logger)
+	logger := crlog.InitControllerRuntimeLogger("transfer-pvc")
 
 	totalPhases := 7
 	if t.isIntraClusterSameNamespace() {

--- a/cmd/tunnel-api/tunnel-api.go
+++ b/cmd/tunnel-api/tunnel-api.go
@@ -3,6 +3,7 @@ package tunnel_api
 import (
 	"fmt"
 
+	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/konveyor/crane-lib/connect/tunnel_api"
 	"github.com/konveyor/crane/internal/flags"
 	"github.com/sirupsen/logrus"
@@ -12,6 +13,7 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type TunnelAPIOptions struct {
@@ -142,6 +144,9 @@ func (t *TunnelAPIOptions) getRestConfigFromContext(ctx string) (*rest.Config, e
 
 func (t *TunnelAPIOptions) run() error {
 	log := t.logger
+	ctrlLogger := logrus.New()
+	logger := logrusr.New(ctrlLogger)
+	ctrllog.SetLogger(logger)
 	tunnel := tunnel_api.Tunnel{}
 
 	fmt.Println("Generating SSL certificates. This may take several minutes.")

--- a/cmd/tunnel-api/tunnel-api.go
+++ b/cmd/tunnel-api/tunnel-api.go
@@ -3,9 +3,9 @@ package tunnel_api
 import (
 	"fmt"
 
-	logrusr "github.com/bombsimon/logrusr/v3"
 	"github.com/konveyor/crane-lib/connect/tunnel_api"
 	"github.com/konveyor/crane/internal/flags"
+	crlog "github.com/konveyor/crane/internal/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -13,7 +13,6 @@ import (
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type TunnelAPIOptions struct {
@@ -144,9 +143,7 @@ func (t *TunnelAPIOptions) getRestConfigFromContext(ctx string) (*rest.Config, e
 
 func (t *TunnelAPIOptions) run() error {
 	log := t.logger
-	ctrlLogger := logrus.New()
-	logger := logrusr.New(ctrlLogger)
-	ctrllog.SetLogger(logger)
+	crlog.InitControllerRuntimeLogger("")
 	tunnel := tunnel_api.Tunnel{}
 
 	fmt.Println("Generating SSL certificates. This may take several minutes.")

--- a/internal/log/controller_runtime.go
+++ b/internal/log/controller_runtime.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	logrusr "github.com/bombsimon/logrusr/v3"
+	"github.com/sirupsen/logrus"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// InitControllerRuntimeLogger initializes the controller-runtime logger
+// to suppress warnings when external libraries create Kubernetes clients.
+// If name is provided, it will be set as the logger name.
+func InitControllerRuntimeLogger(name string) {
+	ctrlLogger := logrus.New()
+	logger := logrusr.New(ctrlLogger)
+	if name != "" {
+		logger = logger.WithName(name)
+	}
+	ctrllog.SetLogger(logger)
+}

--- a/internal/log/controller_runtime.go
+++ b/internal/log/controller_runtime.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	logrusr "github.com/bombsimon/logrusr/v3"
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -9,11 +10,13 @@ import (
 // InitControllerRuntimeLogger initializes the controller-runtime logger
 // to suppress warnings when external libraries create Kubernetes clients.
 // If name is provided, it will be set as the logger name.
-func InitControllerRuntimeLogger(name string) {
+// Returns the initialized logger for use by callers.
+func InitControllerRuntimeLogger(name string) logr.Logger {
 	ctrlLogger := logrus.New()
 	logger := logrusr.New(ctrlLogger)
 	if name != "" {
 		logger = logger.WithName(name)
 	}
 	ctrllog.SetLogger(logger)
+	return logger
 }


### PR DESCRIPTION
## Summary
Initialize controller-runtime logger in three commands (transfer-pvc, tunnel-api, convert)
to suppress controller-runtime warning when external libraries create Kubernetes clients.

## Root Cause
Commands using Kubernetes clients via controller-runtime library never called
`log.SetLogger()`, causing warnings when libraries like pvc-transfer attempt to use
the logger for API operations.

## Changes
- **transfer-pvc**: Added `ctrllog.SetLogger()` in both `run()` and `runIndirect()`
- **tunnel-api**: Added `ctrllog.SetLogger()` in `run()`
- **convert**: Added `ctrllog.SetLogger()` in `run()`

Each command creates a separate controller-runtime logger instance to avoid
affecting audit logging.

## Testing
Verified warning no longer appears when running:
- `crane transfer-pvc`
- `crane tunnel-api`
- `crane convert`

Fixes https://github.com/migtools/crane/issues/896


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized logging across conversion, PVC transfer, and API tunneling commands.
  * Improved consistency in how command-line operations initialize and route log messages.
  * Controller-related messages now use each command’s established logging configuration, providing more consistent output across operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->