### PR TITLE
:seedling: PR digest: show age, filter stale change requests

### DIFF
--- a/.github/workflows/pr-ready-for-review-digest-slack.yml
+++ b/.github/workflows/pr-ready-for-review-digest-slack.yml
@@ -43,10 +43,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # TEMP(testing): read PRs from upstream while validating this workflow on a fork.
-          # Revert to: target_repo="${GITHUB_REPOSITORY}"
-          target_repo="migtools/crane"
-
           # Classify a PR title using Konveyor release-tools prefixes
           # (shortcodes and emoji forms). Strips optional WIP / [tag] prefixes.
           classify_type() {
@@ -101,7 +97,7 @@ jobs:
           # Pad from the visible label (ignore emoji shortcodes).
           section_heading() {
             local label visible
-            label="$1"
+            label="$(section_label "$1")"
             visible="$(printf '%s' "$label" | sed -E 's/:[a-z0-9_+-]+:[[:space:]]*//')"
             local width=36
             local label_len=${#visible}
@@ -117,36 +113,6 @@ jobs:
             left="$(printf '━%.0s' $(seq 1 "${pad}"))"
             right="$(printf '━%.0s' $(seq 1 "${right_pad}"))"
             printf '%s %s %s' "${left}" "${label}" "${right}"
-          }
-
-          stale_threshold_days=7
-
-          pr_age_days() {
-            local created="$1"
-            local epoch_created epoch_now
-            epoch_created="$(date -d "${created}" +%s)"
-            epoch_now="$(date +%s)"
-            echo $(( (epoch_now - epoch_created) / 86400 ))
-          }
-
-          is_stale_pr() {
-            [[ "$(pr_age_days "$1")" -ge "${stale_threshold_days}" ]]
-          }
-
-          format_pr_block() {
-            local n="$1" safe_title="$2" url="$3" author="$4" age="$5"
-            printf '%s. %s\n%s | @%s | opened %s ago' "${n}" "${safe_title}" "${url}" "${author}" "${age}"
-          }
-
-          append_to_section() {
-            local -n blocks_ref=$1
-            local key="$2"
-            local block="$3"
-            if [[ -n "${blocks_ref[$key]:-}" ]]; then
-              blocks_ref[$key]+=$'\n\n'"${block}"
-            else
-              blocks_ref[$key]="${block}"
-            fi
           }
 
           # Human-readable age from an ISO 8601 timestamp (GNU date on ubuntu-latest).
@@ -178,7 +144,7 @@ jobs:
           # CHANGES_REQUESTED on the current head commit (stale reviews on older
           # commits do not block the digest).
           prs_json="$(gh pr list \
-            --repo "${target_repo}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --state open \
             --label ready-for-review-notified \
             --json number,title,url,author,isDraft,createdAt,headRefOid,reviews \
@@ -204,13 +170,10 @@ jobs:
             exit 0
           fi
 
-          # Group by type (feature first). PRs open longer than stale_threshold_days
-          # go in a global Stale section at the end (still grouped by type there).
+          # Group by type (feature first). Number PRs within each section.
           section_order=(feature breaking bugfix test docs infra nonote other)
           declare -A section_blocks
           declare -A section_counts
-          declare -A stale_section_blocks
-          declare -A stale_section_counts
 
           while IFS= read -r row; do
             title="$(printf '%s' "$row" | jq -r '.title')"
@@ -225,16 +188,13 @@ jobs:
             # Escape & first so we do not double-escape later replacements.
             safe_title="$(printf '%s' "$title" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
 
-            if is_stale_pr "${created_at}"; then
-              stale_section_counts[$pr_type]=$(( ${stale_section_counts[$pr_type]:-0} + 1 ))
-              n="${stale_section_counts[$pr_type]}"
-              block="$(format_pr_block "${n}" "${safe_title}" "${url}" "${author}" "${age}")"
-              append_to_section stale_section_blocks "${pr_type}" "${block}"
+            section_counts[$pr_type]=$(( ${section_counts[$pr_type]:-0} + 1 ))
+            n="${section_counts[$pr_type]}"
+            block="${n}. ${safe_title}"$'\n'"${url} | @${author} | opened ${age} ago"
+            if [[ -n "${section_blocks[$pr_type]:-}" ]]; then
+              section_blocks[$pr_type]+=$'\n\n'"${block}"
             else
-              section_counts[$pr_type]=$(( ${section_counts[$pr_type]:-0} + 1 ))
-              n="${section_counts[$pr_type]}"
-              block="$(format_pr_block "${n}" "${safe_title}" "${url}" "${author}" "${age}")"
-              append_to_section section_blocks "${pr_type}" "${block}"
+              section_blocks[$pr_type]="${block}"
             fi
           done < <(printf '%s' "$prs_json" | jq -c '.[]')
 
@@ -248,28 +208,10 @@ jobs:
             if [[ -z "${section_blocks[$pr_type]:-}" ]]; then
               continue
             fi
-            message+="$(section_heading "$(section_label "$pr_type")")"$'\n\n'
+            message+="$(section_heading "$pr_type")"$'\n\n'
             # Extra blank lines after each section for easier scanning in Slack.
             message+="${section_blocks[$pr_type]}"$'\n\n\n\n\n'
           done
-
-          stale_total=0
-          for pr_type in "${section_order[@]}"; do
-            stale_total=$((stale_total + ${stale_section_counts[$pr_type]:-0}))
-          done
-
-          if [[ "${stale_total}" -gt 0 ]]; then
-            stale_label=":hourglass_flowing_sand: Stale PRs (open > ${stale_threshold_days}d)"
-            message+="$(section_heading "${stale_label}")"$'\n\n'
-
-            for pr_type in "${section_order[@]}"; do
-              if [[ -z "${stale_section_blocks[$pr_type]:-}" ]]; then
-                continue
-              fi
-              message+="$(section_heading "$(section_label "$pr_type")")"$'\n\n'
-              message+="${stale_section_blocks[$pr_type]}"$'\n\n\n\n\n'
-            done
-          fi
 
           # Drop trailing blank lines after the last section.
           while [[ "${message}" == *$'\n\n' ]]; do

--- a/.github/workflows/pr-ready-for-review-digest-slack.yml
+++ b/.github/workflows/pr-ready-for-review-digest-slack.yml
@@ -8,6 +8,7 @@
 # 3. Add the trigger URL as repository secret SLACK_RFR_DIGEST_WEBHOOK_URL.
 #
 # Refs: https://github.com/migtools/crane/issues/812
+#       https://github.com/migtools/crane/issues/888
 # Prefixes: https://github.com/konveyor/release-tools/blob/main/pkg/pr/prefix.go
 
 name: PR Ready For Review Daily Digest
@@ -114,15 +115,40 @@ jobs:
             printf '%s %s %s' "${left}" "${label}" "${right}"
           }
 
-          # Fetch open, non-draft PRs with the ready-for-review-notified label.
+          # Human-readable age from an ISO 8601 timestamp (GNU date on ubuntu-latest).
+          format_age() {
+            local created="$1"
+            local epoch_created epoch_now diff days hours
+            epoch_created="$(date -d "${created}" +%s)"
+            epoch_now="$(date +%s)"
+            diff=$((epoch_now - epoch_created))
+            days=$((diff / 86400))
+            if [[ "${days}" -ge 30 ]]; then
+              echo "$((days / 30))mo"
+            elif [[ "${days}" -ge 7 ]]; then
+              echo "$((days / 7))w"
+            elif [[ "${days}" -ge 1 ]]; then
+              echo "${days}d"
+            else
+              hours=$((diff / 3600))
+              if [[ "${hours}" -lt 1 ]]; then
+                echo "<1h"
+              else
+                echo "${hours}h"
+              fi
+            fi
+          }
+
+          # Fetch open PRs with the ready-for-review-notified label; keep only
+          # non-draft PRs without an outstanding changes-requested review.
           prs_json="$(gh pr list \
             --repo "${GITHUB_REPOSITORY}" \
             --state open \
             --label ready-for-review-notified \
-            --json number,title,url,author,isDraft \
+            --json number,title,url,author,isDraft,createdAt,reviewDecision \
             --limit 200)"
 
-          prs_json="$(printf '%s' "$prs_json" | jq '[.[] | select(.isDraft == false)]')"
+          prs_json="$(printf '%s' "$prs_json" | jq '[.[] | select(.isDraft == false and .reviewDecision != "CHANGES_REQUESTED")] | sort_by(.createdAt)')"
           total="$(printf '%s' "$prs_json" | jq 'length')"
 
           if [[ "${total}" -eq 0 ]]; then
@@ -140,6 +166,8 @@ jobs:
             title="$(printf '%s' "$row" | jq -r '.title')"
             url="$(printf '%s' "$row" | jq -r '.url')"
             author="$(printf '%s' "$row" | jq -r '.author.login')"
+            created_at="$(printf '%s' "$row" | jq -r '.createdAt')"
+            age="$(format_age "${created_at}")"
             pr_type="$(classify_type "$title")"
 
             # Escape Slack special characters in author-controlled titles so
@@ -149,7 +177,7 @@ jobs:
 
             section_counts[$pr_type]=$(( ${section_counts[$pr_type]:-0} + 1 ))
             n="${section_counts[$pr_type]}"
-            block="${n}. ${safe_title}"$'\n'"${url} | @${author}"
+            block="${n}. ${safe_title}"$'\n'"${url} | @${author} | opened ${age} ago"
             if [[ -n "${section_blocks[$pr_type]:-}" ]]; then
               section_blocks[$pr_type]+=$'\n\n'"${block}"
             else

--- a/.github/workflows/pr-ready-for-review-digest-slack.yml
+++ b/.github/workflows/pr-ready-for-review-digest-slack.yml
@@ -101,7 +101,7 @@ jobs:
           # Pad from the visible label (ignore emoji shortcodes).
           section_heading() {
             local label visible
-            label="$(section_label "$1")"
+            label="$1"
             visible="$(printf '%s' "$label" | sed -E 's/:[a-z0-9_+-]+:[[:space:]]*//')"
             local width=36
             local label_len=${#visible}
@@ -117,6 +117,36 @@ jobs:
             left="$(printf '━%.0s' $(seq 1 "${pad}"))"
             right="$(printf '━%.0s' $(seq 1 "${right_pad}"))"
             printf '%s %s %s' "${left}" "${label}" "${right}"
+          }
+
+          stale_threshold_days=7
+
+          pr_age_days() {
+            local created="$1"
+            local epoch_created epoch_now
+            epoch_created="$(date -d "${created}" +%s)"
+            epoch_now="$(date +%s)"
+            echo $(( (epoch_now - epoch_created) / 86400 ))
+          }
+
+          is_stale_pr() {
+            [[ "$(pr_age_days "$1")" -ge "${stale_threshold_days}" ]]
+          }
+
+          format_pr_block() {
+            local n="$1" safe_title="$2" url="$3" author="$4" age="$5"
+            printf '%s. %s\n%s | @%s | opened %s ago' "${n}" "${safe_title}" "${url}" "${author}" "${age}"
+          }
+
+          append_to_section() {
+            local -n blocks_ref=$1
+            local key="$2"
+            local block="$3"
+            if [[ -n "${blocks_ref[$key]:-}" ]]; then
+              blocks_ref[$key]+=$'\n\n'"${block}"
+            else
+              blocks_ref[$key]="${block}"
+            fi
           }
 
           # Human-readable age from an ISO 8601 timestamp (GNU date on ubuntu-latest).
@@ -174,10 +204,13 @@ jobs:
             exit 0
           fi
 
-          # Group by type (feature first). Number PRs within each section.
+          # Group by type (feature first). PRs open longer than stale_threshold_days
+          # go in a global Stale section at the end (still grouped by type there).
           section_order=(feature breaking bugfix test docs infra nonote other)
           declare -A section_blocks
           declare -A section_counts
+          declare -A stale_section_blocks
+          declare -A stale_section_counts
 
           while IFS= read -r row; do
             title="$(printf '%s' "$row" | jq -r '.title')"
@@ -192,13 +225,16 @@ jobs:
             # Escape & first so we do not double-escape later replacements.
             safe_title="$(printf '%s' "$title" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g')"
 
-            section_counts[$pr_type]=$(( ${section_counts[$pr_type]:-0} + 1 ))
-            n="${section_counts[$pr_type]}"
-            block="${n}. ${safe_title}"$'\n'"${url} | @${author} | opened ${age} ago"
-            if [[ -n "${section_blocks[$pr_type]:-}" ]]; then
-              section_blocks[$pr_type]+=$'\n\n'"${block}"
+            if is_stale_pr "${created_at}"; then
+              stale_section_counts[$pr_type]=$(( ${stale_section_counts[$pr_type]:-0} + 1 ))
+              n="${stale_section_counts[$pr_type]}"
+              block="$(format_pr_block "${n}" "${safe_title}" "${url}" "${author}" "${age}")"
+              append_to_section stale_section_blocks "${pr_type}" "${block}"
             else
-              section_blocks[$pr_type]="${block}"
+              section_counts[$pr_type]=$(( ${section_counts[$pr_type]:-0} + 1 ))
+              n="${section_counts[$pr_type]}"
+              block="$(format_pr_block "${n}" "${safe_title}" "${url}" "${author}" "${age}")"
+              append_to_section section_blocks "${pr_type}" "${block}"
             fi
           done < <(printf '%s' "$prs_json" | jq -c '.[]')
 
@@ -212,10 +248,28 @@ jobs:
             if [[ -z "${section_blocks[$pr_type]:-}" ]]; then
               continue
             fi
-            message+="$(section_heading "$pr_type")"$'\n\n'
+            message+="$(section_heading "$(section_label "$pr_type")")"$'\n\n'
             # Extra blank lines after each section for easier scanning in Slack.
             message+="${section_blocks[$pr_type]}"$'\n\n\n\n\n'
           done
+
+          stale_total=0
+          for pr_type in "${section_order[@]}"; do
+            stale_total=$((stale_total + ${stale_section_counts[$pr_type]:-0}))
+          done
+
+          if [[ "${stale_total}" -gt 0 ]]; then
+            stale_label=":hourglass_flowing_sand: Stale PRs (open > ${stale_threshold_days}d)"
+            message+="$(section_heading "${stale_label}")"$'\n\n'
+
+            for pr_type in "${section_order[@]}"; do
+              if [[ -z "${stale_section_blocks[$pr_type]:-}" ]]; then
+                continue
+              fi
+              message+="$(section_heading "$(section_label "$pr_type")")"$'\n\n'
+              message+="${stale_section_blocks[$pr_type]}"$'\n\n\n\n\n'
+            done
+          fi
 
           # Drop trailing blank lines after the last section.
           while [[ "${message}" == *$'\n\n' ]]; do

--- a/.github/workflows/pr-ready-for-review-digest-slack.yml
+++ b/.github/workflows/pr-ready-for-review-digest-slack.yml
@@ -144,15 +144,28 @@ jobs:
           }
 
           # Fetch open PRs with the ready-for-review-notified label; keep only
-          # non-draft PRs without an outstanding changes-requested review.
+          # non-draft PRs. Hide a PR only when a reviewer's latest review is
+          # CHANGES_REQUESTED on the current head commit (stale reviews on older
+          # commits do not block the digest).
           prs_json="$(gh pr list \
             --repo "${target_repo}" \
             --state open \
             --label ready-for-review-notified \
-            --json number,title,url,author,isDraft,createdAt,reviewDecision \
+            --json number,title,url,author,isDraft,createdAt,headRefOid,reviews \
             --limit 200)"
 
-          prs_json="$(printf '%s' "$prs_json" | jq '[.[] | select(.isDraft == false and .reviewDecision != "CHANGES_REQUESTED")] | sort_by(.createdAt)')"
+          prs_json="$(printf '%s' "$prs_json" | jq '
+            [.[]
+             | select(.isDraft == false)
+             | . as $pr
+             | select(
+                 (($pr.reviews // [])
+                  | group_by(.author.login)
+                  | map(sort_by(.submittedAt) | last)
+                  | map(select(.state == "CHANGES_REQUESTED" and .commit.oid == $pr.headRefOid))
+                  | length) == 0
+               )
+            ] | sort_by(.createdAt)')"
           total="$(printf '%s' "$prs_json" | jq 'length')"
 
           if [[ "${total}" -eq 0 ]]; then

--- a/.github/workflows/pr-ready-for-review-digest-slack.yml
+++ b/.github/workflows/pr-ready-for-review-digest-slack.yml
@@ -43,6 +43,10 @@ jobs:
         run: |
           set -euo pipefail
 
+          # TEMP(testing): read PRs from upstream while validating this workflow on a fork.
+          # Revert to: target_repo="${GITHUB_REPOSITORY}"
+          target_repo="migtools/crane"
+
           # Classify a PR title using Konveyor release-tools prefixes
           # (shortcodes and emoji forms). Strips optional WIP / [tag] prefixes.
           classify_type() {
@@ -142,7 +146,7 @@ jobs:
           # Fetch open PRs with the ready-for-review-notified label; keep only
           # non-draft PRs without an outstanding changes-requested review.
           prs_json="$(gh pr list \
-            --repo "${GITHUB_REPOSITORY}" \
+            --repo "${target_repo}" \
             --state open \
             --label ready-for-review-notified \
             --json number,title,url,author,isDraft,createdAt,reviewDecision \


### PR DESCRIPTION
## Summary

Updates the daily Slack ready-for-review digest workflow (`.github/workflows/pr-ready-for-review-digest-slack.yml`) to make the digest more actionable for reviewers.

- Shows how long each PR has been open (e.g. `opened 5d ago`) on every digest line.
- Excludes draft PRs from the digest.
- Excludes PRs only when a reviewer's **latest** review is `CHANGES_REQUESTED` on the **current HEAD** commit. PRs where the author pushed fixes after an earlier change request still appear in the digest.
- Keeps existing type-based grouping (feature, bugfix, test, etc.) with oldest PRs listed first within each section.

Closes #888.

## Impact

- **Severity:** Low — workflow-only change; no product code affected.
- **Affected component:** `PR Ready For Review Daily Digest` GitHub Actions workflow and its Slack output.
- **Behavior change:** Digest may include PRs that were previously hidden when `reviewDecision` was `CHANGES_REQUESTED` but the request targeted an older commit.

## Test plan

- [x] Ran `gh pr list` + `jq` filter locally against `migtools/crane` to verify age formatting and head-aware review filtering.
- [x] Triggered workflow via `workflow_dispatch` on fork and confirmed digest message builds successfully.
- [x] Verified PRs with stale change requests (e.g. #355) are included after author pushes new commits.
- [x] Verified PRs with `CHANGES_REQUESTED` on current HEAD are excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull request review digests now display how long each pull request has been open.
  * Digest information includes additional pull request details to improve review visibility.

* **Bug Fixes**
  * Draft pull requests are excluded from review digests.
  * Pull requests with outstanding change requests on their current revision are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->