### PR TITLE
  :sparkles: feat(audit): add audit logging to plugin-manager subcommands + pre-existing security issues

### DIFF
--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -217,7 +217,11 @@ func (o *Options) run(args []string) error {
 	return nil
 }
 
-func downloadBinary(filepath string, filename string, url string, log *logrus.Logger) error {
+func downloadBinary(pluginDir string, filename string, url string, log *logrus.Logger) error {
+	if filepath.Base(filename) != filename || filename == "." || filename == ".." {
+		return fmt.Errorf("invalid plugin filename %q", filename)
+	}
+
 	var binaryContents io.Reader
 	isUrl, url := plugin.IsUrl(url)
 	if !isUrl {
@@ -239,18 +243,18 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 		binaryContents = resp.Body
 	}
 	// Create dir if not exists
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
-		err = os.MkdirAll(filepath, os.ModePerm)
+	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+		err = os.MkdirAll(pluginDir, os.ModePerm)
 		if err != nil {
-			log.Errorf("Failed to create plugin directory %s: %v", filepath, err)
+			log.Errorf("Failed to create plugin directory %s: %v", pluginDir, err)
 			return err
 		}
 	}
 
 	// Create the file
-	pluginBinary, err := os.OpenFile(filepath+"/"+filename, syscall.O_RDWR|syscall.O_CREAT|syscall.O_TRUNC, 0777)
+	pluginBinary, err := os.OpenFile(filepath.Join(pluginDir, filename), syscall.O_RDWR|syscall.O_CREAT|syscall.O_TRUNC, 0755)
 	if err != nil {
-		log.Errorf("Failed to create plugin file %s/%s: %v", filepath, filename, err)
+		log.Errorf("Failed to create plugin file %s/%s: %v", pluginDir, filename, err)
 		return err
 	}
 	defer pluginBinary.Close()
@@ -266,7 +270,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 		log.Errorf("Failed to sync plugin binary %s: %v", filename, err)
 		return err
 	}
-	log.Infof("pluginBinary %s added to the path - %s", filename, filepath)
+	log.Infof("pluginBinary %s added to the path - %s", filename, pluginDir)
 	return err
 }
 

--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -50,8 +50,10 @@ func (o *Options) Complete(c *cobra.Command, args []string) error {
 
 func (o *Options) Validate(args []string) error {
 	// TODO: @jgabani
+	log := o.log
 
 	if len(args) != 1 {
+		log.Warnf("Expected exactly one plugin name, got %d", len(args))
 		return errors.New("please input only one plugin name")
 	}
 
@@ -59,25 +61,30 @@ func (o *Options) Validate(args []string) error {
 		if o.PluginDir == os.Getenv("HOME")+plugin.DefaultLocalPluginDir {
 			o.PluginDir = plugin.GlobalPluginDir
 		} else {
+			log.Warnf("--plugin-dir and --global cannot be used together")
 			return errors.New("--plugin-dir and --global should not be used together.")
 		}
 	}
 
 	pluginDir, err := filepath.Abs(o.PluginDir)
 	if err != nil {
+		log.Errorf("Failed to resolve plugin directory path %q: %v", o.PluginDir, err)
 		return err
 	}
 
 	files, err := ioutil.ReadDir(pluginDir)
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.Debugf("Plugin directory %q does not exist, no installed plugins to check", pluginDir)
 			return nil
 		}
+		log.Errorf("Failed to read plugin directory %q: %v", pluginDir, err)
 		return err
 	}
 
 	paths, err := plugin.LocateBinaryInPluginDir(o.PluginDir, args[0], files)
 	if err != nil {
+		log.Errorf("Failed to locate plugin %s in %q: %v", args[0], o.PluginDir, err)
 		return err
 	}
 
@@ -86,6 +93,7 @@ func (o *Options) Validate(args []string) error {
 		for _, path := range paths {
 			fmt.Printf("%s \n", path)
 		}
+		log.Warnf("Plugin %s is already installed", args[0])
 		return errors.New("the binary is already installed in the above path, either delete the binary or mention a repo from which the binary is needed")
 	}
 	return nil
@@ -134,8 +142,11 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 func (o *Options) run(args []string) error {
 	log := o.log
 
+	log.Infof("Starting plugin-manager add %s...", args[0])
+
 	manifestMap, err := plugin.BuildManifestMap(log, args[0], o.Repo)
 	if err != nil {
+		log.Errorf("Failed to build manifest for plugin %s: %v", args[0], err)
 		return nil
 	}
 
@@ -160,6 +171,7 @@ func (o *Options) run(args []string) error {
 					if value.Name != "" && (o.Version == "" || string(value.Version) == o.Version) {
 						uri, err := binaryURIForPlatform(value)
 						if err != nil {
+							log.Errorf("No binary available for plugin %s on this platform: %v", value.Name, err)
 							return err
 						}
 						return downloadBinary(o.PluginDir, value.Name, uri, log)
@@ -182,6 +194,7 @@ func (o *Options) run(args []string) error {
 					if string(value.Version) == installVersion {
 						uri, err := binaryURIForPlatform(value)
 						if err != nil {
+							log.Errorf("No binary available for plugin %s %s on this platform: %v", value.Name, installVersion, err)
 							return err
 						}
 						return downloadBinary(o.PluginDir, value.Name, uri, log)
@@ -192,12 +205,13 @@ func (o *Options) run(args []string) error {
 			default:
 				// throw error saying that the plugin doest exists
 				log.Errorf("The plugin %s is not found", args[0])
-				fmt.Println(fmt.Sprintf("Run \"crane plugin-manager list\" to list all the available plugins \n"))
+				fmt.Println("Run \"crane plugin-manager list\" to list all the available plugins")
 			}
 		}
 	default:
 		// throw error saying that the plugin doest exists
-		fmt.Println(fmt.Sprintf("Run \"crane plugin-manager list\" to list all the available plugins \n"))
+		log.Warnf("The plugin %s is not found", args[0])
+		fmt.Println("Run \"crane plugin-manager list\" to list all the available plugins")
 		return errors.New(fmt.Sprintf("The plugin %s is not found", args[0]))
 	}
 	return nil
@@ -209,6 +223,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	if !isUrl {
 		srcPlugin, err := os.Open(url)
 		if err != nil {
+			log.Errorf("Failed to open local plugin binary %s: %v", url, err)
 			return err
 		}
 		defer srcPlugin.Close()
@@ -217,6 +232,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 		// Get the data
 		resp, err := http.Get(url)
 		if err != nil {
+			log.Errorf("Failed to download plugin binary from %s: %v", url, err)
 			return err
 		}
 		defer resp.Body.Close()
@@ -226,6 +242,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		err = os.MkdirAll(filepath, os.ModePerm)
 		if err != nil {
+			log.Errorf("Failed to create plugin directory %s: %v", filepath, err)
 			return err
 		}
 	}
@@ -233,6 +250,7 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	// Create the file
 	pluginBinary, err := os.OpenFile(filepath+"/"+filename, syscall.O_RDWR|syscall.O_CREAT|syscall.O_TRUNC, 0777)
 	if err != nil {
+		log.Errorf("Failed to create plugin file %s/%s: %v", filepath, filename, err)
 		return err
 	}
 	defer pluginBinary.Close()
@@ -240,10 +258,12 @@ func downloadBinary(filepath string, filename string, url string, log *logrus.Lo
 	// Write the body to filePluginDir
 	_, err = io.Copy(pluginBinary, binaryContents)
 	if err != nil {
+		log.Errorf("Failed to write plugin binary %s: %v", filename, err)
 		return err
 	}
 	err = pluginBinary.Sync()
 	if err != nil {
+		log.Errorf("Failed to sync plugin binary %s: %v", filename, err)
 		return err
 	}
 	log.Infof("pluginBinary %s added to the path - %s", filename, filepath)

--- a/cmd/plugin-manager/list/list.go
+++ b/cmd/plugin-manager/list/list.go
@@ -101,14 +101,18 @@ func addFlagsForOptions(o *Flags, cmd *cobra.Command) {
 
 func (o *Options) run() error {
 	log := o.log
+
+	log.Infof("Starting plugin-manager list...")
+
 	if o.Installed {
 		// retrieve list of all the plugins that are installed within plugin dir
 		// TODO: differentiate between multiple repos
 		plugins, err := plugin.GetFilteredPlugins(o.PluginDir, []string{}, log)
 		if err != nil {
+			log.Errorf("Failed to get installed plugins from %s: %v", o.PluginDir, err)
 			return err
 		}
-		fmt.Println(fmt.Sprintf("Listing plugins from path - %s, along with default plugin", o.PluginDir))
+		fmt.Printf("Listing plugins from path - %s, along with default plugin\n", o.PluginDir)
 		printInstalledInformation(plugins)
 		return nil
 	}
@@ -117,6 +121,7 @@ func (o *Options) run() error {
 	if o.Name != "" && (o.Params || o.Versions) {
 		manifestMap, err := plugin.BuildManifestMap(log, o.Name, o.Repo)
 		if err != nil {
+			log.Errorf("Failed to build manifest for plugin %s: %v", o.Name, err)
 			return nil
 		}
 		if len(manifestMap) == 0 {
@@ -145,11 +150,12 @@ func (o *Options) run() error {
 	} else {
 		manifestMap, err := plugin.BuildManifestMap(log, "", o.Repo)
 		if err != nil {
+			log.Errorf("Failed to build manifest: %v", err)
 			return nil
 		}
 
 		if o.Name != "" {
-			log.Info(fmt.Sprintf("\"--name\" flag should be used with either \"--versions\" or \"--params\" flag to get more information about the plugin, example: \"crane plugin-manager --name %s --versions\" or \"crane plugin-manager --name %s --params\"\n", o.Name, o.Name))
+			log.Infof("\"--name\" flag should be used with either \"--versions\" or \"--params\" flag to get more information about the plugin, example: \"crane plugin-manager --name %s --versions\" or \"crane plugin-manager --name %s --params\"", o.Name, o.Name)
 		} else if o.Params {
 			// retrieve all the information for all the versions available for a specific plugin
 			for repo, pluginsMap := range manifestMap {

--- a/cmd/plugin-manager/remove/remove.go
+++ b/cmd/plugin-manager/remove/remove.go
@@ -80,25 +80,31 @@ func NewRemoveCommand(f *flags.GlobalFlags) *cobra.Command {
 
 func (o *Options) run(args []string) error {
 	log := o.log
+
+	log.Infof("Starting plugin-manager remove %s...", args[0])
+
 	pluginDir, err := filepath.Abs(fmt.Sprintf("%v/%v", o.PluginDir, o.Repo))
 	if err != nil {
+		log.Errorf("Failed to resolve plugin directory path: %v", err)
 		return err
 	}
 
 	files, err := ioutil.ReadDir(pluginDir)
 	if err != nil {
+		log.Errorf("Failed to read plugin directory %s: %v", pluginDir, err)
 		return err
 	}
 
 	paths, err := plugin.LocateBinaryInPluginDir(pluginDir, args[0], files)
 	if err != nil {
+		log.Errorf("Failed to locate plugin %s in %s: %v", args[0], pluginDir, err)
 		return err
 	}
 
 	if len(paths) > 1 {
 		// fail and ask for a specific repo
-		log.Errorf("The binary is installed from multiple source, please specify repository from which you want to remove the plugin using --repo \n")
-		fmt.Printf("The binary is present in the following path")
+		log.Errorf("The binary is installed from multiple sources, please specify repository from which you want to remove the plugin using --repo")
+		fmt.Println("The binary is present in the following path")
 		for _, path := range paths {
 			fmt.Printf("%s \n", path)
 		}
@@ -108,6 +114,7 @@ func (o *Options) run(args []string) error {
 	} else {
 		err = os.Remove(paths[0])
 		if err != nil {
+			log.Errorf("Failed to remove plugin %s from %s: %v", args[0], paths[0], err)
 			return err
 		}
 		log.Infof("The plugin %s removed from path - %s", args[0], paths[0])


### PR DESCRIPTION
https://github.com/migtools/crane/issues/783

- Adds structured audit logging to the `plugin-manager add`, `list`, and `remove` subcommands, consistent with the           logging patterns already applied to `export`, `transform`, `apply`, `validate`, and `transfer-pvc`.

- Each subcommand now emits `Infof` at start, `Errorf`/`Warnf` before every error return, and `Debugf` for expected silent paths (e.g. plugin directory does not exist yet). All log entries are captured in the persistent JSON audit log file via the existing `FileHook`.

- Also cleans up redundant `fmt.Println(fmt.Sprintf(...))` calls — replaced with `fmt.Println(...)` or `fmt.Printf(...)` as appropriate — and removes trailing `\n` from logrus messages.

-  Fixes two pre-existing security issues in `plugin-manager add` (CWE-22, CWE-276):

     - Plugin filenames from the remote manifest are now validated with `filepath.Base` to prevent path traversal outside    `PluginDir`
      - Plugin binaries are created with mode `0755` instead of `0777`

### Before (no audit logging):
```
$ ./crane plugin-manager add fake-plugin-xyz
Run "crane plugin-manager list" to list all the available plugins
Error: The plugin fake-plugin-xyz is not found

$ cat audit/.crane-audit.log
(empty)
```

### After (with audit logging):
```
$ ./crane plugin-manager add fake-plugin-xyz
INFO Starting plugin-manager add fake-plugin-xyz...
WARN The plugin fake-plugin-xyz is not found
Run "crane plugin-manager list" to list all the available plugins
Error: The plugin fake-plugin-xyz is not found

$ cat audit/.crane-audit.log
{"cmd":"plugin-manager add","level":"debug","msg":"Plugin directory \"/Users/tdinavet/.local/share/crane/plugins\" does not exist, no installed plugins to check","time":"2026-09-06T12:21:53+03:00"}
{"cmd":"plugin-manager add","level":"info","msg":"Starting plugin-manager add fake-plugin-xyz...","time":"2026-09-06T12:21:53+03:00"}
{"cmd":"plugin-manager add","level":"warning","msg":"The plugin fake-plugin-xyz is not found","time":"2026-09-06T12:21:53+03:00"}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added clearer logging throughout plugin installation, listing, and removal operations.
  * Improved error messages for plugin discovery, manifest processing, file operations, and removal failures.
  * Simplified plugin-not-found and informational command output for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->