### PR TITLE
:seedling: allow reviewers to run /rfr on github-actions[bot] PRs

### DIFF
--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -51,11 +51,22 @@ jobs:
             exit 0
           fi
 
-          # Allow PR author to trigger, or allow anyone if PR is authored by github-actions[bot]
-          if [[ "$commenter" != "$pr_author" && "$pr_author" != "github-actions[bot]" ]]; then
-            echo "::notice::Ignoring command from @${commenter}; only PR author @${pr_author} can trigger."
-            echo "should_notify=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          # Authorization: PR author can always trigger; for bot-authored PRs, require write access
+          if [[ "$commenter" != "$pr_author" ]]; then
+            if [[ "$pr_author" == "github-actions[bot]" ]]; then
+              # For bot-authored PRs, check if commenter has write access to the repo
+              permission=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${commenter}/permission" --jq '.permission' 2>/dev/null || echo "none")
+              if [[ "$permission" != "admin" && "$permission" != "write" ]]; then
+                echo "::notice::Ignoring command from @${commenter}; only maintainers with write access can trigger /rfr on bot-authored PRs."
+                echo "should_notify=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "::notice::Allowing @${commenter} (permission: ${permission}) to trigger /rfr on bot-authored PR."
+            else
+              echo "::notice::Ignoring command from @${commenter}; only PR author @${pr_author} can trigger."
+              echo "should_notify=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           comment_id="$(jq -r '.comment.id' "$GITHUB_EVENT_PATH")"

--- a/.github/workflows/pr-ready-for-review-slack.yml
+++ b/.github/workflows/pr-ready-for-review-slack.yml
@@ -51,7 +51,8 @@ jobs:
             exit 0
           fi
 
-          if [[ "$commenter" != "$pr_author" ]]; then
+          # Allow PR author to trigger, or allow anyone if PR is authored by github-actions[bot]
+          if [[ "$commenter" != "$pr_author" && "$pr_author" != "github-actions[bot]" ]]; then
             echo "::notice::Ignoring command from @${commenter}; only PR author @${pr_author} can trigger."
             echo "should_notify=false" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary

When a PR is authored by `github-actions[bot]` (e.g., automated code-to-docs updates), human reviewers can now trigger the `/rfr` command. Previously, only the PR author could trigger it, which was impossible for bot-authored PRs since bots can't comment commands.

## Changes

Updated the author check in `.github/workflows/pr-ready-for-review-slack.yml` to allow any user to trigger `/rfr` when the PR author is `github-actions[bot]`.

**Before:**
```bash
if [[ "$commenter" != "$pr_author" ]]; then
  # block non-authors
fi
```

**After:**
```bash
# Allow PR author to trigger, or allow anyone if PR is authored by github-actions[bot]
if [[ "$commenter" != "$pr_author" && "$pr_author" != "github-actions[bot]" ]]; then
  # block non-authors only for human-authored PRs
fi
```

## Impact

- **Low risk** - Only affects the `/rfr` Slack notification workflow
- **No breaking changes** - Existing behavior for human-authored PRs is preserved

## Test Plan

1. Create a PR using `github-actions[bot]` (or simulate with an existing bot-authored PR)
2. Have a non-author comment `/rfr`
3. Verify the Slack notification is sent (previously would be blocked)

Fixes #911



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the pull request review workflow so PR authors can trigger the process as before.
  - For pull requests created by the automated bot, any commenter can now trigger the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->