### PR TITLE
:seedling: increase ginkgo suite timeout + job timeouts

### DIFF
--- a/.github/actions/run-crane-e2e-tier/action.yml
+++ b/.github/actions/run-crane-e2e-tier/action.yml
@@ -124,4 +124,4 @@ runs:
           GINKGO_ARGS+=(--rclone-config-file="${{ inputs.rclone_config_file }}")
         fi
 
-        ginkgo run -v -r --label-filter="${{ inputs.label_filter }}" e2e-tests/tests -- "${GINKGO_ARGS[@]}"
+        ginkgo run -v -r --timeout=90m --label-filter="${{ inputs.label_filter }}" e2e-tests/tests -- "${GINKGO_ARGS[@]}"

--- a/.github/workflows/e2e-indirect-pr-tester.yaml
+++ b/.github/workflows/e2e-indirect-pr-tester.yaml
@@ -145,7 +145,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
 
       - name: Run tier0 e2e tests (indirect)
         run: |
-          ginkgo run -v -r --label-filter="tier0" e2e-tests/tests -- \
+          ginkgo run -v -r --timeout=90m --label-filter="tier0" e2e-tests/tests -- \
             --k8sdeploy-bin=k8sdeploy \
             --crane-bin=${{ github.workspace }}/crane \
             --source-context=src \
@@ -212,7 +212,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -262,7 +262,7 @@ jobs:
 
       - name: Run tier1 e2e tests (indirect)
         run: |
-          ginkgo run -v -r --label-filter="tier1" e2e-tests/tests -- \
+          ginkgo run -v -r --timeout=90m --label-filter="tier1" e2e-tests/tests -- \
             --k8sdeploy-bin=k8sdeploy \
             --crane-bin=${{ github.workspace }}/crane \
             --source-context=src \
@@ -280,7 +280,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       CRANE_BIN: ${{ github.workspace }}/crane
       E2E_SUITE_DIR: e2e-tests/tests
@@ -335,7 +335,7 @@ jobs:
         env:
           FOCUS_FILE_REGEX: ${{ needs.detect-changes.outputs.focus_file_regex }}
         run: |
-          ginkgo run -v -r --focus-file="$FOCUS_FILE_REGEX" "$E2E_SUITE_DIR" -- \
+          ginkgo run -v -r --timeout=90m --focus-file="$FOCUS_FILE_REGEX" "$E2E_SUITE_DIR" -- \
             --k8sdeploy-bin=k8sdeploy \
             --crane-bin=$CRANE_BIN \
             --source-context=src \

--- a/.github/workflows/e2e-pr-tester.yaml
+++ b/.github/workflows/e2e-pr-tester.yaml
@@ -166,7 +166,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       CRANE_BIN: ${{ github.workspace }}/crane
       E2E_SUITE_DIR: e2e-tests/tests
@@ -226,7 +226,7 @@ jobs:
         env:
           FOCUS_FILE_REGEX: ${{ needs.detect-changes.outputs.focus_file_regex }}
         run: |
-          ginkgo run -v -r --focus-file="$FOCUS_FILE_REGEX" "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
+          ginkgo run -v -r --timeout=90m --focus-file="$FOCUS_FILE_REGEX" "$E2E_SUITE_DIR" -- $GINKGO_COMMON_ARGS
 
   # Keep job id run-changed-e2e-tests so existing required checks keep matching.
   # Pass only when the active path (parallel tiers or focused) succeeded.

--- a/.github/workflows/reusable-e2e-tier-tests.yml
+++ b/.github/workflows/reusable-e2e-tier-tests.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   run-e2e:
     runs-on: ubuntu-22.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Automated end-to-end test runs now enforce a 90-minute test execution limit.
  - Overall test jobs can run for up to 120 minutes, providing additional time for setup, teardown, and result collection.
  - These limits apply consistently across standard, indirect, tiered, and focused end-to-end test runs, helping prevent stalled or excessively long validation jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->