### PR TITLE
:bug: Fix dest pvc already mounted issue

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -711,26 +711,37 @@ func getValidatedResourceName(name string) string {
 	}
 }
 
-// getNodeNameForPVC returns name of the node on which the PVC is currently mounted on
-// returns name of the node as a string, and an error
-func getNodeNameForPVC(srcClient client.Client, namespace string, pvcName string) (string, error) {
+// getRunningPodUsingPVC returns the running pod that mounts pvcName, if any.
+func getRunningPodUsingPVC(c client.Client, namespace string, pvcName string) (*corev1.Pod, error) {
 	podList := corev1.PodList{}
-	err := srcClient.List(context.TODO(), &podList, client.InNamespace(namespace))
-	if err != nil {
-		return "", err
+	if err := c.List(context.TODO(), &podList, client.InNamespace(namespace)); err != nil {
+		return nil, err
 	}
-	for _, pod := range podList.Items {
+	for i := range podList.Items {
+		pod := &podList.Items[i]
 		if pod.Status.Phase == corev1.PodRunning {
 			for _, vol := range pod.Spec.Volumes {
 				if vol.PersistentVolumeClaim != nil {
 					if vol.PersistentVolumeClaim.ClaimName == pvcName {
-						return pod.Spec.NodeName, nil
+						return pod, nil
 					}
 				}
 			}
 		}
 	}
-	return "", nil
+	return nil, nil
+}
+
+// getNodeNameForPVC returns the name of the node on which the PVC is currently mounted.
+func getNodeNameForPVC(c client.Client, namespace string, pvcName string) (string, error) {
+	pod, err := getRunningPodUsingPVC(c, namespace, pvcName)
+	if err != nil {
+		return "", err
+	}
+	if pod == nil {
+		return "", nil
+	}
+	return pod.Spec.NodeName, nil
 }
 
 func getIDsForNamespace(c client.Client, namespace string, pvcName string, image string) (*corev1.PodSecurityContext, error) {
@@ -1290,8 +1301,9 @@ func (t *TransferPVCCommand) buildDestinationPVC(sourcePVC *corev1.PersistentVol
 	return pvc
 }
 
-// createDestinationPVC creates the destination PVC, validating the storage
-// class of an existing PVC when --dest-storage-class was requested.
+// createDestinationPVC creates the destination PVC, ensuring an existing PVC
+// is not mounted by a running pod and validating its storage class when
+// --dest-storage-class was requested.
 func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.Client, pvc *corev1.PersistentVolumeClaim) error {
 	if err := c.Create(ctx, pvc, &client.CreateOptions{}); err == nil {
 		return nil
@@ -1299,13 +1311,21 @@ func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.
 		return fmt.Errorf("creating destination PVC %q: %w", pvc.Name, err)
 	}
 
-	if t.PVC.StorageClassName == "" {
-		return nil
-	}
-
 	existing := &corev1.PersistentVolumeClaim{}
 	if err := c.Get(ctx, client.ObjectKeyFromObject(pvc), existing); err != nil {
 		return fmt.Errorf("getting existing destination PVC %q: %w", pvc.Name, err)
+	}
+
+	pod, err := getRunningPodUsingPVC(c, existing.Namespace, existing.Name)
+	if err != nil {
+		return fmt.Errorf("checking whether destination PVC %s/%s is in use: %w", existing.Namespace, existing.Name, err)
+	}
+	if pod != nil {
+		return fmt.Errorf("destination PVC %s/%s is in use by pod %q; scale it down before transferring", existing.Namespace, existing.Name, pod.Name)
+	}
+
+	if t.PVC.StorageClassName == "" {
+		return nil
 	}
 
 	existingStorageClass := ""

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -713,18 +713,34 @@ func getValidatedResourceName(name string) string {
 
 // getRunningPodUsingPVC returns the running pod that mounts pvcName, if any.
 func getRunningPodUsingPVC(c client.Client, namespace string, pvcName string) (*corev1.Pod, error) {
+	return getPodUsingPVC(c, namespace, pvcName, func(pod *corev1.Pod) bool {
+		return pod.Status.Phase == corev1.PodRunning
+	})
+}
+
+// getActivePodUsingPVC returns a non-terminal pod that references pvcName, if any.
+// Pending pods are included because Kubernetes may attach and mount a PVC before
+// an init container or application container starts.
+func getActivePodUsingPVC(c client.Client, namespace string, pvcName string) (*corev1.Pod, error) {
+	return getPodUsingPVC(c, namespace, pvcName, func(pod *corev1.Pod) bool {
+		return pod.Status.Phase != corev1.PodSucceeded && pod.Status.Phase != corev1.PodFailed
+	})
+}
+
+func getPodUsingPVC(c client.Client, namespace string, pvcName string, include func(*corev1.Pod) bool) (*corev1.Pod, error) {
 	podList := corev1.PodList{}
 	if err := c.List(context.TODO(), &podList, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		if pod.Status.Phase == corev1.PodRunning {
-			for _, vol := range pod.Spec.Volumes {
-				if vol.PersistentVolumeClaim != nil {
-					if vol.PersistentVolumeClaim.ClaimName == pvcName {
-						return pod, nil
-					}
+		if !include(pod) {
+			continue
+		}
+		for _, vol := range pod.Spec.Volumes {
+			if vol.PersistentVolumeClaim != nil {
+				if vol.PersistentVolumeClaim.ClaimName == pvcName {
+					return pod, nil
 				}
 			}
 		}
@@ -1302,7 +1318,7 @@ func (t *TransferPVCCommand) buildDestinationPVC(sourcePVC *corev1.PersistentVol
 }
 
 // createDestinationPVC creates the destination PVC, ensuring an existing PVC
-// is not mounted by a running pod and validating its storage class when
+// is not referenced by a non-terminal pod and validating its storage class when
 // --dest-storage-class was requested.
 func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.Client, pvc *corev1.PersistentVolumeClaim) error {
 	if err := c.Create(ctx, pvc, &client.CreateOptions{}); err == nil {
@@ -1316,7 +1332,7 @@ func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.
 		return fmt.Errorf("getting existing destination PVC %q: %w", pvc.Name, err)
 	}
 
-	pod, err := getRunningPodUsingPVC(c, existing.Namespace, existing.Name)
+	pod, err := getActivePodUsingPVC(c, existing.Namespace, existing.Name)
 	if err != nil {
 		return fmt.Errorf("checking whether destination PVC %s/%s is in use: %w", existing.Namespace, existing.Name, err)
 	}

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -70,6 +70,7 @@ func TestCreateDestinationPVC(t *testing.T) {
 		name                  string
 		requestedStorageClass string
 		existingStorageClass  *string
+		objects               []client.Object
 		wantErr               string
 	}{
 		{
@@ -87,6 +88,24 @@ func TestCreateDestinationPVC(t *testing.T) {
 			name:                 "accepts existing PVC when no storage class was requested",
 			existingStorageClass: storageClass("crane-sc02-target"),
 		},
+		{
+			name: "rejects existing PVC mounted by a running pod without requested storage class",
+			objects: []client.Object{&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "target-app", Namespace: "test-ns"},
+				Spec: corev1.PodSpec{
+					NodeName: "worker-1",
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+						},
+					}},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}},
+			existingStorageClass: storageClass("standard-v2"),
+			wantErr:              `destination PVC test-ns/test-pvc is in use by pod "target-app"; scale it down before transferring`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -95,7 +114,8 @@ func TestCreateDestinationPVC(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "test-ns"},
 				Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: tt.existingStorageClass},
 			}
-			c := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(existing).Build()
+			objects := append([]client.Object{existing}, tt.objects...)
+			c := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(objects...).Build()
 			cmd := &TransferPVCCommand{Flags: Flags{PVC: PvcFlags{StorageClassName: tt.requestedStorageClass}}}
 
 			err := cmd.createDestinationPVC(context.Background(), c, &corev1.PersistentVolumeClaim{

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -106,6 +106,24 @@ func TestCreateDestinationPVC(t *testing.T) {
 			existingStorageClass: storageClass("standard-v2"),
 			wantErr:              `destination PVC test-ns/test-pvc is in use by pod "target-app"; scale it down before transferring`,
 		},
+		{
+			name: "rejects existing PVC referenced by a pending pod with an init container",
+			objects: []client.Object{&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "target-app-initializing", Namespace: "test-ns"},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init", Image: "busybox:1.36"}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "test-pvc"},
+						},
+					}},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodPending},
+			}},
+			existingStorageClass: storageClass("standard-v2"),
+			wantErr:              `destination PVC test-ns/test-pvc is in use by pod "target-app-initializing"; scale it down before transferring`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
+++ b/e2e-tests/tests/tier0/mta_898_stage_cutover_migration_test.go
@@ -90,9 +90,14 @@ var _ = Describe("Stage and cutover migration flow", func() {
 			PVCNamespaceMap: fmt.Sprintf("%s:%s", srcApp.Namespace, tgtApp.Namespace),
 			Subdomain:       fmt.Sprintf("%s.%s.%s.nip.io", pvcName, srcApp.Namespace, tgtIP),
 		}
+		waitForTransferCleanup := func() {
+			AssertNoTransferPVCLeftovers(kubectlSrc, []string{srcApp.Namespace}, pvcName)
+			AssertNoTransferPVCLeftovers(kubectlTgt, []string{tgtApp.Namespace}, pvcName)
+		}
 
 		By("Run the first stage transfer-pvc while the app is still running on source")
 		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+		waitForTransferCleanup()
 
 		By("Verify the source app is unaffected and still running after the stage sync")
 		srcPhase, err := kubectlSrc.Run("get", "pod", srcPodName, "-n", srcApp.Namespace, "-o", "jsonpath={.status.phase}")
@@ -153,6 +158,7 @@ var _ = Describe("Stage and cutover migration flow", func() {
 			Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
 			By("Skipping incremental sync verification for indirect mode (pods are ephemeral)")
 		}
+		waitForTransferCleanup()
 
 		By("Verify no data is missing: both the initial and new keys are present on target")
 		Expect(DeployVerifierPod(kubectlTgt, verifierOpts)).NotTo(HaveOccurred())
@@ -187,6 +193,7 @@ var _ = Describe("Stage and cutover migration flow", func() {
 		Expect(runner.Export(exportOpts)).NotTo(HaveOccurred())
 		Expect(runner.Transform(transformOpts)).NotTo(HaveOccurred())
 		Expect(runner.TransferPVC(transferOpts)).NotTo(HaveOccurred())
+		waitForTransferCleanup()
 		Expect(runner.Apply(applyOpts)).NotTo(HaveOccurred())
 
 		By("Verify rendered output excludes the PVC: it is migrated separately via transfer-pvc")


### PR DESCRIPTION
Fixes #905 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented transfers from proceeding when the destination storage claim is mounted by a running or pending pod.
  - Added guidance to scale down the pod before retrying the transfer.
  - Improved validation when destination storage claims already exist, helping prevent conflicts during transfers.

- **Reliability**
  - Added cleanup verification after staging and cutover operations to ensure temporary transfer resources are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->