### PR TITLE
:test_tube: Add --plugin-dir flag registration for all tests

### DIFF
--- a/e2e-tests/config/config.go
+++ b/e2e-tests/config/config.go
@@ -18,6 +18,7 @@ var (
 	CloudStorage          string
 	RcloneConfigFile      string
 	RcloneConfigSecret    string
+	PluginDir             string
 )
 
 // Validates the --run-as flag value and logs the active mode.

--- a/e2e-tests/tests/tier0/e2e_suite_test.go
+++ b/e2e-tests/tests/tier0/e2e_suite_test.go
@@ -25,6 +25,7 @@ func init() {
 	flag.StringVar(&config.CloudStorage, "cloud-storage", "", "S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)")
 	flag.StringVar(&config.RcloneConfigFile, "rclone-config-file", "", "Path to local rclone.conf file for indirect transfer")
 	flag.StringVar(&config.RcloneConfigSecret, "rclone-config-secret", "", "K8s Secret name containing rclone.conf for indirect transfer")
+	flag.StringVar(&config.PluginDir, "plugin-dir", "", "Directory containing crane transform plugins")
 }
 
 var _ = BeforeSuite(func() {

--- a/e2e-tests/tests/tier1/e2e_suite_test.go
+++ b/e2e-tests/tests/tier1/e2e_suite_test.go
@@ -25,6 +25,7 @@ func init() {
 	flag.StringVar(&config.CloudStorage, "cloud-storage", "", "S3-compatible cloud storage path for indirect transfer (e.g. remote:my-bucket)")
 	flag.StringVar(&config.RcloneConfigFile, "rclone-config-file", "", "Path to local rclone.conf file for indirect transfer")
 	flag.StringVar(&config.RcloneConfigSecret, "rclone-config-secret", "", "K8s Secret name containing rclone.conf for indirect transfer")
+	flag.StringVar(&config.PluginDir, "plugin-dir", "", "Directory containing crane transform plugins")
 }
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
## Summary

This PR adds the `--plugin-dir` CLI flag to the e2e test framework **without implementing any test logic**. This is a minimal change to prevent test failures while the pipeline passes this flag.

## Problem

The Jenkins pipeline (after merge of migrationqe-automation MR #1450) now passes `--plugin-dir` to ALL test runs:
```bash
ginkgo run ... -- ... --plugin-dir=/path/to/plugins
```

But other test branches don't have this flag registered, causing:
```
flag provided but not defined: -plugin-dir
```

## Solution

Register the flag in the test framework so it's available to all tests, even if they don't use it.

**Changes:**
- `e2e-tests/config/config.go`: Add `PluginDir` global variable
- `e2e-tests/tests/tier0/e2e_suite_test.go`: Register `--plugin-dir` flag
- `e2e-tests/tests/tier1/e2e_suite_test.go`: Register `--plugin-dir` flag

## Impact

- Tests that don't use plugins will simply ignore the flag
- Tests that need it (like MTA-819) can access it via `config.PluginDir`
- No behavioral changes for existing tests
- Allows pipeline to pass the flag without breaking other tests

## Related

- Prerequisite for #935 (MTA-819 BuildConfig to Shipwright e2e test)
- Required by migrationqe-automation MR #1450 (already merged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--plugin-dir` command-line option to configure the directory containing Crane transform plugins.
  * The setting is available across tier 0 and tier 1 end-to-end test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->