### PR TITLE
:sparkles: Update crane-lib to 20260904

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/gnostic-models v0.7.0
 	github.com/google/go-cmp v0.7.0
 	github.com/jarcoal/httpmock v1.2.0
-	github.com/konveyor/crane-lib v0.1.6-0.20260824070743-b8fa732fccd4
+	github.com/konveyor/crane-lib v0.1.6-0.20260904122213-e20819ac61ad
 	github.com/migtools/pvc-transfer v0.0.0-20260820041907-3bfa753b411a
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d h1:ynlHX9Rg4+
 github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/konveyor/crane-lib v0.1.6-0.20260824070743-b8fa732fccd4 h1:95MyFCfEnTnBL8By+BqsVT2RIQ2UNWD6nGBc4IHuAdE=
 github.com/konveyor/crane-lib v0.1.6-0.20260824070743-b8fa732fccd4/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
+github.com/konveyor/crane-lib v0.1.6-0.20260904122213-e20819ac61ad h1:MXl/7yI2sCV2BiAkdJ2ZAtdUzBqjyd9cXOwkSDfKhRM=
+github.com/konveyor/crane-lib v0.1.6-0.20260904122213-e20819ac61ad/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
# Summary

Update `github.com/konveyor/crane-lib` to `v0.1.6-0.20260904122213-e20819ac61ad`.

This brings in the following crane-lib changes:

- `bc06be4` Whiteout Events in KubernetesPlugin (https://github.com/migtools/crane-lib/pull/159)
- `e20819a` Preserve user-created service account secret types (https://github.com/migtools/crane-lib/pull/160)

## Impact

Low risk. The updated library excludes Kubernetes Events during export and ensures that user-created ServiceAccount secret types are preserved.

Fixes https://github.com/migtools/crane/issues/920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal library dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->