### PR TITLE
:bug: fix transfer-pvc hanging in case of terminating dest pvc

### DIFF
--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1289,8 +1289,8 @@ func (t *TransferPVCCommand) buildDestinationPVC(sourcePVC *corev1.PersistentVol
 	return pvc
 }
 
-// createDestinationPVC creates the destination PVC, validating the storage
-// class of an existing PVC when --dest-storage-class was requested.
+// createDestinationPVC creates the destination PVC, validating that an
+// existing PVC is not terminating and its storage class when requested.
 func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.Client, pvc *corev1.PersistentVolumeClaim) error {
 	if err := c.Create(ctx, pvc, &client.CreateOptions{}); err == nil {
 		return nil
@@ -1298,13 +1298,16 @@ func (t *TransferPVCCommand) createDestinationPVC(ctx context.Context, c client.
 		return fmt.Errorf("creating destination PVC %q: %w", pvc.Name, err)
 	}
 
-	if t.PVC.StorageClassName == "" {
-		return nil
-	}
-
 	existing := &corev1.PersistentVolumeClaim{}
 	if err := c.Get(ctx, client.ObjectKeyFromObject(pvc), existing); err != nil {
 		return fmt.Errorf("getting existing destination PVC %q: %w", pvc.Name, err)
+	}
+	if existing.DeletionTimestamp != nil {
+		return fmt.Errorf("destination PVC %q is terminating; transfer cannot proceed until it has been fully deleted. Remove the finalizer blocking deletion or wait for deletion to complete, then retry", client.ObjectKeyFromObject(existing))
+	}
+
+	if t.PVC.StorageClassName == "" {
+		return nil
 	}
 
 	existingStorageClass := ""

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -70,8 +70,14 @@ func TestCreateDestinationPVC(t *testing.T) {
 		name                  string
 		requestedStorageClass string
 		existingStorageClass  *string
+		deletionTimestamp     *metav1.Time
 		wantErr               string
 	}{
+		{
+			name:              "rejects an existing PVC that is terminating",
+			deletionTimestamp: &metav1.Time{},
+			wantErr:           `destination PVC "test-ns/test-pvc" is terminating; transfer cannot proceed until it has been fully deleted`,
+		},
 		{
 			name:                  "rejects existing PVC with a different requested storage class",
 			requestedStorageClass: "standard-v2",
@@ -95,7 +101,22 @@ func TestCreateDestinationPVC(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test-pvc", Namespace: "test-ns"},
 				Spec:       corev1.PersistentVolumeClaimSpec{StorageClassName: tt.existingStorageClass},
 			}
-			c := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(existing).Build()
+			builder := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(existing)
+			if tt.deletionTimestamp != nil {
+				builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := c.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						if existingPVC, ok := obj.(*corev1.PersistentVolumeClaim); ok {
+							existingPVC.DeletionTimestamp = tt.deletionTimestamp
+							existingPVC.Finalizers = []string{"crane.io/stuck-for-test"}
+						}
+						return nil
+					},
+				})
+			}
+			c := builder.Build()
 			cmd := &TransferPVCCommand{Flags: Flags{PVC: PvcFlags{StorageClassName: tt.requestedStorageClass}}}
 
 			err := cmd.createDestinationPVC(context.Background(), c, &corev1.PersistentVolumeClaim{


### PR DESCRIPTION
Fixes #810 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Destination volume transfers are now blocked when the destination volume is still being deleted.
  * Transfers can proceed after the destination volume finishes deletion, preventing operations against a terminating resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->