### PR TITLE
:test_tube: add test for transfer-pvc numbered phases and summary

### DIFF
--- a/e2e-tests/framework/client_test.go
+++ b/e2e-tests/framework/client_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestHasDefaultStorageClassAnnotation(t *testing.T) {
 	tests := []struct {
-		name         string
-		annotations  map[string]string
-		wantDefault  bool
+		name        string
+		annotations map[string]string
+		wantDefault bool
 	}{
 		{
 			name: "ga annotation marks default",
@@ -51,6 +51,58 @@ func TestHasDefaultStorageClassAnnotation(t *testing.T) {
 
 			if got := hasDefaultStorageClassAnnotation(storageClass); got != tt.wantDefault {
 				t.Fatalf("hasDefaultStorageClassAnnotation() = %v, want %v", got, tt.wantDefault)
+			}
+		})
+	}
+}
+
+func TestAssertTransferPVCProgressOutput(t *testing.T) {
+	const output = `
+[1/3] Reading source PVC ... ok
+[2/3] Creating endpoint (nginx-ingress) ... ok
+[3/3] Copying data (rsync) ... finished  exit=0
+
+Summary
+-------
+PVC data copy: succeeded
+duration:      1s
+Done.
+`
+
+	tests := []struct {
+		name    string
+		output  string
+		phases  []string
+		summary string
+		wantErr bool
+	}{
+		{
+			name:    "accepts complete direct output",
+			output:  output,
+			phases:  []string{"Reading source PVC", "Creating endpoint", "Copying data (rsync)"},
+			summary: "PVC data copy: succeeded",
+		},
+		{
+			name:    "reports missing phase",
+			output:  output,
+			phases:  []string{"Reading source PVC", "Cleaning up temporary resources"},
+			summary: "PVC data copy: succeeded",
+			wantErr: true,
+		},
+		{
+			name:    "reports missing summary status",
+			output:  output,
+			phases:  []string{"Reading source PVC"},
+			summary: "PVC data copy: failed",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := AssertTransferPVCProgressOutput(tt.output, 3, tt.phases, tt.summary)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("AssertTransferPVCProgressOutput() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/e2e-tests/framework/crane.go
+++ b/e2e-tests/framework/crane.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/konveyor/crane/e2e-tests/config"
 )
@@ -26,6 +27,10 @@ type TransferPVCOptions struct {
 	CloudStorage       string
 	RcloneConfigFile   string
 	RcloneConfigSecret string
+	// DisableCloudStorage prevents the runner from inheriting the suite-wide
+	// cloud storage configuration. It is useful when direct and indirect
+	// transfer coverage run in the same E2E invocation.
+	DisableCloudStorage bool
 }
 
 // ValidateOptions contains arguments for the crane validate command.
@@ -199,7 +204,14 @@ func (c CraneRunner) Apply(opts ApplyOptions) error {
 // Otherwise uses direct rsync/stunnel.
 // If Endpoint is empty in direct mode, it auto-detects: "route" on OpenShift, "nginx-ingress" on vanilla K8s.
 func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
-	if opts.CloudStorage == "" && config.CloudStorage != "" {
+	_, err := c.TransferPVCWithOutput(opts)
+	return err
+}
+
+// TransferPVCWithOutput runs crane transfer-pvc and returns its combined stdout
+// and stderr. This permits E2E tests to assert CLI progress and summary output.
+func (c CraneRunner) TransferPVCWithOutput(opts TransferPVCOptions) (string, error) {
+	if !opts.DisableCloudStorage && opts.CloudStorage == "" && config.CloudStorage != "" {
 		opts.CloudStorage = config.CloudStorage
 	}
 	if opts.RcloneConfigFile == "" && opts.RcloneConfigSecret == "" {
@@ -252,7 +264,31 @@ func (c CraneRunner) TransferPVC(opts TransferPVCOptions) error {
 	out, err := cmd.CombinedOutput()
 	logVerboseOutput("crane transfer-pvc", out)
 	if err != nil {
-		return fmt.Errorf("crane transfer-pvc failed: %v, output: %s", err, string(out))
+		return string(out), fmt.Errorf("crane transfer-pvc failed: %v, output: %s", err, string(out))
+	}
+	return string(out), nil
+}
+
+// AssertTransferPVCProgressOutput verifies that transfer-pvc emitted every
+// numbered phase and a successful final summary. Phase names intentionally
+// omit the completion suffix because the data-copy phase ends with "finished"
+// while the setup and cleanup phases end with "ok".
+func AssertTransferPVCProgressOutput(output string, totalPhases int, phaseNames []string, summary string) error {
+	for i, name := range phaseNames {
+		phase := fmt.Sprintf("[%d/%d] %s", i+1, totalPhases, name)
+		if !strings.Contains(output, phase) {
+			return fmt.Errorf("transfer-pvc output is missing progress phase %q", phase)
+		}
+	}
+
+	if !strings.Contains(output, "Summary\n-------") {
+		return fmt.Errorf("transfer-pvc output is missing the final summary")
+	}
+	if !strings.Contains(output, summary) {
+		return fmt.Errorf("transfer-pvc output is missing summary status %q", summary)
+	}
+	if !strings.Contains(output, "Done.") {
+		return fmt.Errorf("transfer-pvc output is missing completion marker")
 	}
 	return nil
 }

--- a/e2e-tests/tests/tier1/mta_817_transfer_pvc_progress_test.go
+++ b/e2e-tests/tests/tier1/mta_817_transfer_pvc_progress_test.go
@@ -1,0 +1,120 @@
+package e2e
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/konveyor/crane/e2e-tests/config"
+	. "github.com/konveyor/crane/e2e-tests/framework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("transfer-pvc progress output", func() {
+	It("[MTA-817] reports numbered phases and a final summary for direct transfer",
+		Label("tier1", "pvc-transfer", "direct"), func() {
+			runTransferPVCProgressScenario(false)
+		})
+
+	It("[MTA-817] reports numbered phases and a final summary for indirect transfer",
+		Label("tier1", "pvc-transfer", "indirect"), func() {
+			if config.CloudStorage == "" {
+				Skip("indirect transfer coverage requires --cloud-storage")
+			}
+			if config.RcloneConfigFile == "" && config.RcloneConfigSecret == "" {
+				Skip("indirect transfer coverage requires an rclone config file or Secret")
+			}
+			runTransferPVCProgressScenario(true)
+		})
+})
+
+// runTransferPVCProgressScenario uses the existing lightweight unattached-PVC
+// app and seed-pod utilities. It isolates this test to transfer-pvc output;
+// data-integrity and full migration workflow are already covered elsewhere.
+func runTransferPVCProgressScenario(indirect bool) {
+	mode := "direct"
+	if indirect {
+		mode = "indirect"
+	}
+	namespace := "mta-817-progress-" + mode
+	const (
+		appName     = "pvc"
+		pvcName     = "data-pvc"
+		seedPodName = "mta-817-seed"
+	)
+
+	scenario := NewMigrationScenario(
+		appName, namespace, config.K8sDeployBin, config.CraneBin,
+		config.SourceContext, config.TargetContext,
+	)
+	srcApp := scenario.SrcAppNonAdmin
+	tgtApp := scenario.TgtAppNonAdmin
+	srcApp.ExtraVars = map[string]any{
+		"non_admin_user": "true",
+		"pvc_name":       pvcName,
+	}
+
+	kubectlSrc, _, rbacCleanup, err := SetupActiveKubectlRunners(scenario, namespace)
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(rbacCleanup)
+	DeferCleanup(func() {
+		for _, k := range []KubectlRunner{scenario.KubectlSrc, scenario.KubectlTgt} {
+			if _, err := k.Run("delete", "namespace", namespace, "--ignore-not-found=true", "--wait=true"); err != nil {
+				log.Printf("cleanup namespace %q on context %q: %v", namespace, k.Context, err)
+			}
+		}
+	})
+
+	paths, err := NewScenarioPaths("crane-mta-817-" + mode + "-*")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		if err := CleanupScenario(paths.TempDir, srcApp, tgtApp); err != nil {
+			log.Printf("cleanup apps/tempdir: %v", err)
+		}
+	})
+
+	By("Deploy and seed an unattached source PVC")
+	Expect(srcApp.Deploy()).NotTo(HaveOccurred())
+	Expect(kubectlSrc.ApplyYAMLSpec(SeedPodManifest(namespace, seedPodName, pvcName), namespace)).NotTo(HaveOccurred())
+	_, err = kubectlSrc.Run("wait", "--for=condition=Ready", "pod/"+seedPodName, "-n", namespace, "--timeout=120s")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = kubectlSrc.Run("delete", "pod", seedPodName, "-n", namespace, "--wait=true")
+	Expect(err).NotTo(HaveOccurred())
+
+	options := TransferPVCOptions{
+		SourceContext:       srcApp.Context,
+		TargetContext:       tgtApp.Context,
+		PVCName:             pvcName,
+		PVCNamespaceMap:     fmt.Sprintf("%s:%s", namespace, namespace),
+		DisableCloudStorage: !indirect,
+	}
+	var totalPhases int
+	var phaseNames []string
+	if indirect {
+		options.CloudStorage = config.CloudStorage
+		options.RcloneConfigFile = config.RcloneConfigFile
+		options.RcloneConfigSecret = config.RcloneConfigSecret
+		totalPhases = 6
+		phaseNames = []string{
+			"Reading source PVC", "Creating destination PVC", "Uploading data to cloud storage",
+			"Downloading data from cloud storage", "Cleaning up cloud storage", "Cleaning up transfer pods",
+		}
+	} else {
+		targetIP, err := GetClusterNodeIP(tgtApp.Context)
+		Expect(err).NotTo(HaveOccurred())
+		options.Subdomain = fmt.Sprintf("%s.%s.%s.nip.io", pvcName, namespace, targetIP)
+		totalPhases = 7
+		phaseNames = []string{
+			"Reading source PVC", "Creating destination PVC", "Creating endpoint",
+			"Waiting for endpoint healthy", "Setting up secure tunnel and server",
+			"Copying data (rsync)", "Cleaning up temporary resources",
+		}
+	}
+
+	By("Transfer the PVC and verify the CLI progress ladder and final summary")
+	runner := scenario.CraneNonAdmin
+	runner.WorkDir = paths.TempDir
+	output, err := runner.TransferPVCWithOutput(options)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(AssertTransferPVCProgressOutput(output, totalPhases, phaseNames, "PVC data copy: succeeded")).To(Succeed())
+}

--- a/e2e-tests/tests/tier1/mta_817_transfer_pvc_progress_test.go
+++ b/e2e-tests/tests/tier1/mta_817_transfer_pvc_progress_test.go
@@ -100,7 +100,9 @@ func runTransferPVCProgressScenario(indirect bool) {
 			"Downloading data from cloud storage", "Cleaning up cloud storage", "Cleaning up transfer pods",
 		}
 	} else {
-		targetIP, err := GetClusterNodeIP(tgtApp.Context)
+		// Node discovery is cluster-scoped, so use the scenario's admin context.
+		// transfer-pvc itself continues to run through the namespace-admin runner.
+		targetIP, err := GetClusterNodeIP(scenario.KubectlTgt.Context)
 		Expect(err).NotTo(HaveOccurred())
 		options.Subdomain = fmt.Sprintf("%s.%s.%s.nip.io", pvcName, namespace, targetIP)
 		totalPhases = 7


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for direct and indirect PVC transfers.
  * Validated that transfer output displays each numbered progress phase, a final summary, and successful completion status.
  * Added checks for incomplete or missing progress information.
  * Expanded transfer testing to cover configurations with and without cloud storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->