### PR TITLE
:bug: fix(audit): Return error when audit log file cannot be created

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -46,8 +46,11 @@ func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// Store positional arguments as requested stages
 	o.RequestedStages = args
 	o.globalFlags.SetCmdName("apply")
-	o.log = o.globalFlags.GetLoggerOrDefault()
-
+    logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/convert/convert.go
+++ b/cmd/convert/convert.go
@@ -1,6 +1,8 @@
 package convert
 
 import (
+	"fmt"
+	
 	"github.com/konveyor/crane-lib/convert"
 	"github.com/konveyor/crane/internal/flags"
 	crlog "github.com/konveyor/crane/internal/log"
@@ -76,7 +78,11 @@ func (t *ConvertOptions) Complete(c *cobra.Command, args []string) error {
 	if t.debug {
 		t.globalFlags.Debug = true
 	}
-	t.Logger = t.globalFlags.GetLoggerOrDefault()
+	logger, err := t.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    t.Logger=logger
 	return nil
 }
 

--- a/cmd/export/export.go
+++ b/cmd/export/export.go
@@ -56,7 +56,11 @@ type ExportOptions struct {
 func (o *ExportOptions) Complete(c *cobra.Command, args []string) error {
 	var err error
 	o.globalFlags.SetCmdName("export")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	log := o.log
 
 	if c != nil {

--- a/cmd/plugin-manager/add/add.go
+++ b/cmd/plugin-manager/add/add.go
@@ -44,7 +44,11 @@ type Flags struct {
 func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// TODO: @jgabani
 	o.globalFlags.SetCmdName("plugin-manager add")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/plugin-manager/list/list.go
+++ b/cmd/plugin-manager/list/list.go
@@ -48,7 +48,11 @@ type AvailablePlugins struct {
 func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// TODO: @jgabani
 	o.globalFlags.SetCmdName("plugin-manager list")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/plugin-manager/remove/remove.go
+++ b/cmd/plugin-manager/remove/remove.go
@@ -35,7 +35,11 @@ type Flags struct {
 func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// TODO: @jgabani
 	o.globalFlags.SetCmdName("plugin-manager remove")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/skopeo-sync-gen/skopeo-sync-gen.go
+++ b/cmd/skopeo-sync-gen/skopeo-sync-gen.go
@@ -3,7 +3,7 @@ package skopeo_sync_gen
 import (
 	"context"
 	"encoding/json"
-	// "fmt"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,7 +120,11 @@ func (o *Options) Run() error {
 		return err
 	}
 
-	files, err := file.ReadFilesWithLogger(context.TODO(), exportDir, o.globalFlags.GetLoggerOrDefault())
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+	files, err := file.ReadFilesWithLogger(context.TODO(), exportDir, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -206,7 +206,11 @@ func addFlagsToTransferPVCCommand(c *Flags, cmd *cobra.Command) {
 
 func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
 	t.globalFlags.SetCmdName("transfer-pvc")
-	t.log = t.globalFlags.GetLoggerOrDefault()
+	logger, err := t.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+	t.log = logger
 	config := t.configFlags.ToRawKubeConfigLoader()
 	rawConfig, err := config.RawConfig()
 	if err != nil {
@@ -246,7 +250,12 @@ func (t *TransferPVCCommand) Complete(c *cobra.Command, args []string) error {
 func (t *TransferPVCCommand) Validate() error {
 	log := t.log
 	if log == nil {
-		log = t.globalFlags.GetLoggerOrDefault()
+		logger, err := t.globalFlags.GetLoggerOrDefault()
+		if err != nil {
+			return fmt.Errorf("failed to initialize audit logger: %w", err)
+		}
+		log = logger
+
 	}
 	cloudStorage := t.CloudStorage
 

--- a/cmd/transform/listplugins/listplugins.go
+++ b/cmd/transform/listplugins/listplugins.go
@@ -34,7 +34,11 @@ type Flags struct {
 func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// TODO: @sseago
 	o.globalFlags.SetCmdName("transform listplugins")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/transform/optionals/optionals.go
+++ b/cmd/transform/optionals/optionals.go
@@ -33,7 +33,11 @@ type Flags struct {
 func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// TODO: @sseago
 	o.globalFlags.SetCmdName("transform optionals")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=logger
 	return nil
 }
 

--- a/cmd/transform/transform.go
+++ b/cmd/transform/transform.go
@@ -58,7 +58,11 @@ func (o *Options) Complete(c *cobra.Command, args []string) error {
 	// Store positional arguments as requested stages
 	o.RequestedStages = args
 	o.globalFlags.SetCmdName("transform")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	logger, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+	o.log = logger
 	return nil
 }
 
@@ -108,7 +112,10 @@ func getPluginCompletions(f *flags.GlobalFlags) func(cmd *cobra.Command, args []
 
 		// Get plugin names using shared function
 		f.SetCmdName("transform")
-		log := f.GetLoggerOrDefault()
+		log, err := f.GetLoggerOrDefault()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
 		pluginNames, err := listplugins.GetPluginNames(pluginDir, skipPlugins, log)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/tunnel-api/tunnel-api.go
+++ b/cmd/tunnel-api/tunnel-api.go
@@ -77,7 +77,11 @@ func addFlagsForTunnelAPIOptions(t *TunnelAPIOptions, cmd *cobra.Command) {
 
 func (t *TunnelAPIOptions) Complete(c *cobra.Command, args []string) error {
 	t.globalFlags.SetCmdName("tunnel-api")
-	t.logger = t.globalFlags.GetLoggerOrDefault()
+	logger, err := t.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    t.logger=logger
 	config := t.configFlags.ToRawKubeConfigLoader()
 	rawConfig, err := config.RawConfig()
 	if err != nil {

--- a/cmd/validate/validate.go
+++ b/cmd/validate/validate.go
@@ -38,7 +38,11 @@ type ValidateOptions struct {
 // Skipped in offline mode (--api-resources).
 func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	o.globalFlags.SetCmdName("validate")
-	o.log = o.globalFlags.GetLoggerOrDefault()
+	log, err := o.globalFlags.GetLoggerOrDefault()
+	if err != nil {
+		return fmt.Errorf("failed to initialize audit logger: %w", err)
+	}
+    o.log=log
 
 	kubeconfigFlag := c.Flags().Lookup("kubeconfig")
 	if kubeconfigFlag == nil || !kubeconfigFlag.Changed {
@@ -49,7 +53,7 @@ func (o *ValidateOptions) Complete(c *cobra.Command, args []string) error {
 	if o.apiResourcesFile != "" {
 		return nil
 	}
-	_, err := o.configFlags.ToDiscoveryClient()
+	_, err = o.configFlags.ToDiscoveryClient()
 	if err != nil {
 		o.log.Errorf("Failed to create discovery client: %v", err)
 		return err

--- a/internal/flags/global_flags.go
+++ b/internal/flags/global_flags.go
@@ -36,9 +36,9 @@ func (g *GlobalFlags) SetCmdName(name string) {
 }
 
 // GetLoggerOrDefault returns the configured logger, or logrus.StandardLogger() if GlobalFlags is nil.
-func (g *GlobalFlags) GetLoggerOrDefault() *logrus.Logger {
+func (g *GlobalFlags) GetLoggerOrDefault() (*logrus.Logger, error) {
 	if g == nil {
-		return logrus.StandardLogger()
+		return logrus.StandardLogger(), nil
 	}
 	return g.GetLogger()
 }
@@ -49,7 +49,7 @@ func isCompletionMode() bool {
 	return len(os.Args) > 1 && (os.Args[1] == "__complete" || os.Args[1] == "__completeNoDesc")
 }
 
-func (g *GlobalFlags) GetLogger() *logrus.Logger {
+func (g *GlobalFlags) GetLogger() (*logrus.Logger, error) {
 	if g.logger == nil {
 		g.logger = logrus.New()
 		g.logger.SetLevel(logrus.DebugLevel)
@@ -63,10 +63,11 @@ func (g *GlobalFlags) GetLogger() *logrus.Logger {
 				g.logger.AddHook(fileHook)
 			} else {
 				g.logger.Warnf("Failed to open audit log file %s: %v", g.AuditLogPath, err)
+				return g.logger, err
 			}
 		}
 	}
-	return g.logger
+	return g.logger, nil
 }
 
 // Close releases the audit log file. Call this when the program exits.
@@ -87,6 +88,11 @@ func (g *GlobalFlags) initConfig() {
 		if err := viper.UnmarshalKey("audit-log", &g.AuditLogPath); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: invalid audit-log value in %s: %v\n", viper.ConfigFileUsed(), err)
 		}
-		g.GetLogger().Infof("Using config file: %v", viper.ConfigFileUsed())
+		logger, err := g.GetLogger()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to initialize audit logger: %v\n", err)
+		} else {
+			logger.Infof("Using config file: %v", viper.ConfigFileUsed())
+		}
 	}
 }


### PR DESCRIPTION
https://github.com/migtools/crane/issues/945

## Summary
- Make `GetLogger()` and `GetLoggerOrDefault()` return `(*logrus.Logger, error)` to propagate audit log creation failures
- Add error checks in all command `Complete()` methods to fail early if audit log cannot be initialized
- Handle completion functions specially (return `ShellCompDirectiveError` instead of propagating error)
- Update `initConfig()` to handle logger initialization error

## Fixes
Previously, when the audit log path couldn't be created, crane would warn but continue executing without writing any audit data. Now it fails before running the command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Logger initialization errors are now preserved and reported consistently across commands.
  - Command execution stops when required logger setup fails, preventing operations with incomplete logging.
  - Configuration loading continues when audit logging cannot be initialized, while the issue is surfaced as a warning.
  - Audit logging is skipped when no audit log path is configured.
  - Merged configuration values are now applied correctly during command startup.
  - Logger setup now occurs consistently before command execution begins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->