### PR TITLE
:test_tube: Add e2e test for audit log multi-command accumulation

### DIFF
--- a/e2e-tests/testdata/audit-log-export/audit-log-namespace.yaml
+++ b/e2e-tests/testdata/audit-log-export/audit-log-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: validate-core-v1-plural

--- a/e2e-tests/testdata/audit-log-export/audit-log-pod.yaml
+++ b/e2e-tests/testdata/audit-log-export/audit-log-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: validate-core-v1-plural-pod
+  namespace: validate-core-v1-plural
+spec:
+  containers:
+    - name: busybox
+      image: busybox:latest
+      command: ["sh", "-c", "exit 0"]
+  restartPolicy: Never

--- a/e2e-tests/testdata/audit-log-export/audit-log-pvc.yaml
+++ b/e2e-tests/testdata/audit-log-export/audit-log-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: validate-core-v1-plural-pvc
+  namespace: validate-core-v1-plural
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi

--- a/e2e-tests/testdata/audit-log-export/audit-log-serviceaccount.yaml
+++ b/e2e-tests/testdata/audit-log-export/audit-log-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: validate-core-v1-plural-sa
+  namespace: validate-core-v1-plural

--- a/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
+++ b/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
@@ -17,12 +17,13 @@ var _ = Describe("Audit logging multi-command accumulation", func() {
 		Expect(err).NotTo(HaveOccurred())
 		log.Printf("Created temp directory: %s\n", paths.TempDir)
 
+		testdataExportDir, err := utils.TestdataFilePath("audit-log-export")
+		Expect(err).NotTo(HaveOccurred())
+
 		runner := &framework.CraneRunner{
 			Bin:     "crane",
 			WorkDir: paths.TempDir,
 		}
-
-		testdataExportDir := filepath.Join("e2e-tests", "testdata", "audit-log-export")
 
 		transformOpts := framework.TransformOptions{
 			ExportDir:    testdataExportDir,

--- a/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
+++ b/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/konveyor/crane/e2e-tests/framework"
+	"github.com/konveyor/crane/e2e-tests/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Audit logging multi-command accumulation", func() {
+	It("[MTA-915] transform + apply accumulate entries in default audit log", Label("tier0"), func() {
+		paths, err := framework.NewScenarioPaths("crane-audit-*")
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Created temp directory: %s\n", paths.TempDir)
+
+		runner := &framework.CraneRunner{
+			Bin:     "crane",
+			WorkDir: paths.TempDir,
+		}
+
+		testdataExportDir := filepath.Join("e2e-tests", "testdata", "audit-log-export")
+
+		transformOpts := framework.TransformOptions{
+			ExportDir:    testdataExportDir,
+			TransformDir: paths.TransformDir,
+		}
+		applyOpts := framework.ApplyOptions{
+			TransformDir: paths.TransformDir,
+			OutputDir:    paths.OutputDir,
+		}
+
+		DeferCleanup(func() {
+			By("Cleanup temp directory")
+			if err := os.RemoveAll(paths.TempDir); err != nil {
+				log.Printf("cleanup: failed to remove temp dir: %v", err)
+			}
+		})
+
+		By("Run crane transform (offline)")
+		log.Printf("Running crane transform from %s to %s\n", testdataExportDir, paths.TransformDir)
+		Expect(runner.Transform(transformOpts)).NotTo(HaveOccurred())
+		log.Printf("Transform completed successfully\n")
+
+		By("Run crane apply (offline)")
+		log.Printf("Running crane apply from %s to %s\n", paths.TransformDir, paths.OutputDir)
+		Expect(runner.Apply(applyOpts)).NotTo(HaveOccurred())
+		log.Printf("Apply completed successfully\n")
+
+		defaultAuditLog := filepath.Join(paths.TempDir, "audit", ".crane-audit.log")
+
+		By("Verify audit directory exists")
+		auditDir := filepath.Join(paths.TempDir, "audit")
+		info, err := os.Stat(auditDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue(), "audit directory should exist")
+		log.Printf("Audit directory exists: %s\n", auditDir)
+
+		By("Verify audit log file exists with 0600 permissions")
+		fileInfo, err := os.Stat(defaultAuditLog)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(fileInfo.Mode().Perm()).To(Equal(os.FileMode(0o600)))
+		log.Printf("Audit log file exists with 0600 permissions: %s\n", defaultAuditLog)
+
+		By("Read and parse audit log entries")
+		entries, err := utils.ReadAuditLogEntries(defaultAuditLog)
+		Expect(err).NotTo(HaveOccurred())
+		log.Printf("Read %d entries from audit log\n", len(entries))
+
+		By("Verify entries are not empty")
+		Expect(entries).NotTo(BeEmpty(), "audit log should contain entries")
+
+		By("Verify transform entries exist")
+		hasTransformEntry := false
+		for _, entry := range entries {
+			if cmd, ok := entry["cmd"].(string); ok && cmd == "transform" {
+				hasTransformEntry = true
+				break
+			}
+		}
+		Expect(hasTransformEntry).To(BeTrue(), "audit log should contain transform entries")
+		log.Printf("Found transform entries\n")
+
+		By("Verify apply entries exist")
+		hasApplyEntry := false
+		for _, entry := range entries {
+			if cmd, ok := entry["cmd"].(string); ok && cmd == "apply" {
+				hasApplyEntry = true
+				break
+			}
+		}
+		Expect(hasApplyEntry).To(BeTrue(), "audit log should contain apply entries")
+		log.Printf("Found apply entries\n")
+
+		By("Verify transform entries appear before apply entries")
+		transformIndex := -1
+		applyIndex := -1
+		for i, entry := range entries {
+			if cmd, ok := entry["cmd"].(string); ok {
+				if cmd == "transform" && transformIndex == -1 {
+					transformIndex = i
+				}
+				if cmd == "apply" && applyIndex == -1 {
+					applyIndex = i
+				}
+			}
+		}
+		Expect(transformIndex).NotTo(Equal(-1), "transform entries should exist")
+		Expect(applyIndex).NotTo(Equal(-1), "apply entries should exist")
+		Expect(transformIndex < applyIndex).To(BeTrue(), "transform entries should appear before apply entries")
+		log.Printf("Transform entries appear at index %d, apply entries at index %d\n", transformIndex, applyIndex)
+
+		By("Verify JSON validity and required fields (covered by ReadAuditLogEntries)")
+		for i, entry := range entries {
+			Expect(entry).To(HaveKey("cmd"))
+			Expect(entry).To(HaveKey("level"))
+			Expect(entry).To(HaveKey("msg"))
+			Expect(entry).To(HaveKey("time"))
+			log.Printf("Entry %d: cmd=%s, level=%s\n", i, entry["cmd"], entry["level"])
+		}
+	})
+})

--- a/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
+++ b/e2e-tests/tests/tier0/mta_915_audit_logging_accumulation_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/konveyor/crane/e2e-tests/config"
 	"github.com/konveyor/crane/e2e-tests/framework"
 	"github.com/konveyor/crane/e2e-tests/utils"
 	. "github.com/onsi/ginkgo/v2"
@@ -21,7 +22,7 @@ var _ = Describe("Audit logging multi-command accumulation", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		runner := &framework.CraneRunner{
-			Bin:     "crane",
+			Bin:     config.CraneBin,
 			WorkDir: paths.TempDir,
 		}
 

--- a/e2e-tests/utils/utils.go
+++ b/e2e-tests/utils/utils.go
@@ -1449,3 +1449,36 @@ func AssertResourcesDontExist(dir string, resources []ResourceMatch) (bool, erro
 	}
 	return true, nil
 }
+
+// ReadAuditLogEntries reads a JSON Lines audit log file and returns a slice of entries.
+// Validates that each line is valid JSON with required fields: cmd, level, msg, time.
+func ReadAuditLogEntries(path string) ([]map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read audit log: %w", err)
+	}
+
+	var entries []map[string]interface{}
+	lines := bytes.Split(bytes.TrimRight(data, "\n"), []byte("\n"))
+
+	for i, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var entry map[string]interface{}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			return nil, fmt.Errorf("line %d: invalid JSON: %w", i+1, err)
+		}
+
+		requiredFields := []string{"cmd", "level", "msg", "time"}
+		for _, field := range requiredFields {
+			if _, ok := entry[field]; !ok {
+				return nil, fmt.Errorf("line %d: missing required field %q", i+1, field)
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}

--- a/e2e-tests/utils/utils_test.go
+++ b/e2e-tests/utils/utils_test.go
@@ -2045,3 +2045,107 @@ func TestFileHasPrefixAndSuffix(t *testing.T) {
 		})
 	}
 }
+
+func TestReadAuditLogEntries(t *testing.T) {
+	cases := []struct {
+		name        string
+		content     string
+		wantCount   int
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "valid_entries",
+			content: `{"cmd":"transform","level":"info","msg":"test1","time":"2026-09-10T21:00:00+00:00"}
+{"cmd":"apply","level":"info","msg":"test2","time":"2026-09-10T21:00:01+00:00"}`,
+			wantCount: 2,
+			wantErr:   false,
+		},
+		{
+			name: "valid_entries_with_trailing_newline",
+			content: `{"cmd":"transform","level":"info","msg":"test","time":"2026-09-10T21:00:00+00:00"}
+`,
+			wantCount: 1,
+			wantErr:   false,
+		},
+		{
+			name:        "blank_lines_ignored",
+			content:     `{"cmd":"transform","level":"info","msg":"test","time":"2026-09-10T21:00:00+00:00"}
+
+{"cmd":"apply","level":"info","msg":"test2","time":"2026-09-10T21:00:01+00:00"}`,
+			wantCount: 2,
+			wantErr:   false,
+		},
+		{
+			name:        "invalid_json",
+			content:     `{"cmd":"transform","level":"info","msg":"test"`,
+			wantErr:     true,
+			errContains: "invalid JSON",
+		},
+		{
+			name:        "missing_required_field_cmd",
+			content:     `{"level":"info","msg":"test","time":"2026-09-10T21:00:00+00:00"}`,
+			wantErr:     true,
+			errContains: "missing required field",
+		},
+		{
+			name:        "missing_required_field_level",
+			content:     `{"cmd":"transform","msg":"test","time":"2026-09-10T21:00:00+00:00"}`,
+			wantErr:     true,
+			errContains: "missing required field",
+		},
+		{
+			name:        "missing_required_field_msg",
+			content:     `{"cmd":"transform","level":"info","time":"2026-09-10T21:00:00+00:00"}`,
+			wantErr:     true,
+			errContains: "missing required field",
+		},
+		{
+			name:        "missing_required_field_time",
+			content:     `{"cmd":"transform","level":"info","msg":"test"}`,
+			wantErr:     true,
+			errContains: "missing required field",
+		},
+		{
+			name:        "file_not_found",
+			content:     "",
+			wantErr:     true,
+			errContains: "read audit log",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			tmpFile := t.TempDir()
+			var logPath string
+
+			if tc.name != "file_not_found" {
+				logPath = filepath.Join(tmpFile, "audit.log")
+				if err := os.WriteFile(logPath, []byte(tc.content), 0644); err != nil {
+					t.Fatalf("setup: write temp file: %v", err)
+				}
+			} else {
+				logPath = filepath.Join(tmpFile, "nonexistent.log")
+			}
+
+			entries, err := ReadAuditLogEntries(logPath)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Fatalf("error = %v, want to contain %q", err, tc.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(entries) != tc.wantCount {
+					t.Fatalf("got %d entries, want %d", len(entries), tc.wantCount)
+				}
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -337,10 +337,6 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d h1:ynlHX9Rg4+qAuP0uSn24MyIOQMvW1JJz/p0A+045y78=
-github.com/konveyor/crane-lib v0.1.6-0.20260820041859-f7a1f8ac605d/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
-github.com/konveyor/crane-lib v0.1.6-0.20260824070743-b8fa732fccd4 h1:95MyFCfEnTnBL8By+BqsVT2RIQ2UNWD6nGBc4IHuAdE=
-github.com/konveyor/crane-lib v0.1.6-0.20260824070743-b8fa732fccd4/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/konveyor/crane-lib v0.1.6-0.20260904122213-e20819ac61ad h1:MXl/7yI2sCV2BiAkdJ2ZAtdUzBqjyd9cXOwkSDfKhRM=
 github.com/konveyor/crane-lib v0.1.6-0.20260904122213-e20819ac61ad/go.mod h1:oYw915/11lZhW5k+nVxZtWdpl5AGc0lL52Z1YcKjU7Y=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=


### PR DESCRIPTION
https://github.com/migtools/crane/issues/962

## Summary

- Add e2e test MTA-915 for audit logging multi-command accumulation (tier0, positive TC)
- Verifies that `crane transform` + `crane apply` entries accumulate in default audit log path
- Validates audit log file permissions (0600), JSON validity, required fields (cmd, level, msg, time), and command ordering

## Test plan

- ✅ Create TempDir with subdirs (transform, output, audit)
- ✅ Run `crane transform` offline on static testdata export directory
- ✅ Run `crane apply` offline on transform output directory
- ✅ Verify audit directory auto-created at `TempDir/audit/`
- ✅ Verify default audit log file exists at `TempDir/audit/.crane-audit.log`
- ✅ Verify audit log file has 0600 permissions
- ✅ Parse audit log entries and validate JSON + required fields
- ✅ Verify entries from both commands are present
- ✅ Verify transform entries appear before apply entries (append order)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for offline transform and apply commands.
  * Verifies audit logs are created with secure permissions, accumulate entries in the expected sequence, and include required fields.
  * Validates audit-log parsing, blank-line handling, cleanup behavior, and clear errors for invalid or incomplete entries.
  * Added scenarios covering namespace, pod, persistent volume claim, and service account resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->