### PR TITLE
:bug: transfer-pvc[indirect]: fail early when rsync excludes rclone

### DIFF
--- a/cmd/transfer-pvc/indirect.go
+++ b/cmd/transfer-pvc/indirect.go
@@ -138,6 +138,24 @@ func (t *TransferPVCCommand) runIndirect() error {
 		}
 	}
 
+	// Compute the source pod security context now so the rclone-image probe
+	// below runs with the same context the upload pod will use, and reuse it
+	// when building the transfer.
+	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name, t.SourceImage)
+	if err != nil {
+		log.Warnf("Could not determine source security context: %v", err)
+		uploadSecCtx = &corev1.PodSecurityContext{}
+	}
+
+	// Indirect transfer runs rclone as the pod entrypoint. Verify SourceImage
+	// provides rclone before creating the destination PVC, so an image without it
+	// fails clearly here rather than later with an opaque pod failure.
+	fmt.Fprintf(os.Stderr, "Verifying rclone is available in the transfer image ...\n")
+	if err := verifyRcloneInImage(srcClient, srcPVC.Namespace, t.SourceImage, *uploadSecCtx); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Verifying rclone is available in the transfer image ... ok\n")
+
 	// Create destination PVC
 	fmt.Fprintf(os.Stderr, "[2/6] Creating destination PVC ...\n")
 	destPVC := t.buildDestinationPVC(srcPVC)
@@ -148,14 +166,9 @@ func (t *TransferPVCCommand) runIndirect() error {
 	}
 	fmt.Fprintf(os.Stderr, "[2/6] Creating destination PVC ... ok\n")
 
-	// Get security contexts for source and target separately
-	uploadSecCtx, err := getSourcePodSecurityContext(srcClient, srcPVC.Namespace, srcPVC.Name, t.SourceImage)
-	if err != nil {
-		log.Warnf("Could not determine source security context: %v", err)
-		uploadSecCtx = &corev1.PodSecurityContext{}
-	}
-
-	// Indirect transfer uses a single Image (SourceImage) for upload and download.
+	// Get the target security context (uploadSecCtx was computed earlier for the
+	// rclone-image probe). Indirect transfer uses a single Image (SourceImage)
+	// for upload and download.
 	downloadSecCtx, err := getTargetPodSecurityContext(destClient, destPVC.Namespace, destPVC.Name, t.SourceImage)
 	if err != nil {
 		log.Warnf("Could not determine target security context: %v", err)

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1058,6 +1058,87 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string, 
 	return &uid, nil
 }
 
+// verifyRcloneInImage runs a short-lived pod that execs "rclone --version" with
+// the given image and the mover pod's security context, confirming the image
+// ships a runnable rclone binary before crane commits any side effects.
+func verifyRcloneInImage(c client.Client, namespace string, image string, secCtx corev1.PodSecurityContext) error {
+	resolved := rsyncTransferImage(image)
+	podName := fmt.Sprintf("crane-rclone-check-%x", sha256.Sum256([]byte(resolved)))
+	if len(podName) > 63 {
+		podName = podName[:63]
+	}
+
+	nsName := types.NamespacedName{Name: podName, Namespace: namespace}
+	checkPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:   corev1.RestartPolicyNever,
+			SecurityContext: &secCtx,
+			Containers: []corev1.Container{
+				{
+					Name:    "rclone-check",
+					Image:   resolved,
+					Command: []string{"rclone", "--version"},
+				},
+			},
+		},
+	}
+
+	// Best-effort removal of any stale check pod from a previous run so Create
+	// succeeds (the pod name is deterministic per image).
+	_ = c.Delete(context.TODO(), checkPod)
+	_ = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		return errors.IsNotFound(c.Get(ctx, nsName, &corev1.Pod{})), nil
+	})
+
+	if err := c.Create(context.TODO(), checkPod); err != nil {
+		return fmt.Errorf("creating rclone-check pod: %w", err)
+	}
+	defer func() {
+		_ = c.Delete(context.TODO(), checkPod)
+	}()
+
+	// Allow generous time for a cold image pull; once pulled, "rclone version"
+	// (or its StartError when the binary is missing) resolves in seconds.
+	if err := wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 180*time.Second, true, func(ctx context.Context) (bool, error) {
+		pod := &corev1.Pod{}
+		if err := c.Get(ctx, nsName, pod); err != nil {
+			return false, nil
+		}
+		return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed, nil
+	}); err != nil {
+		// Surface a stuck-container reason (e.g. ErrImagePull) if we have one.
+		pod := &corev1.Pod{}
+		if getErr := c.Get(context.TODO(), nsName, pod); getErr == nil && len(pod.Status.ContainerStatuses) > 0 {
+			if w := pod.Status.ContainerStatuses[0].State.Waiting; w != nil {
+				return fmt.Errorf("timed out verifying rclone in image %q: container waiting (%s): %s",
+					resolved, w.Reason, strings.TrimSpace(w.Message))
+			}
+		}
+		return fmt.Errorf("timed out verifying rclone in image %q: %w", resolved, err)
+	}
+
+	pod := &corev1.Pod{}
+	if err := c.Get(context.TODO(), nsName, pod); err != nil {
+		return fmt.Errorf("getting rclone-check pod status: %w", err)
+	}
+	if len(pod.Status.ContainerStatuses) == 0 || pod.Status.ContainerStatuses[0].State.Terminated == nil {
+		return fmt.Errorf("could not verify rclone in image %q: rclone-check pod %s/%s did not terminate normally",
+			resolved, namespace, podName)
+	}
+
+	terminated := pod.Status.ContainerStatuses[0].State.Terminated
+	if terminated.ExitCode != 0 {
+		return fmt.Errorf(
+			"image %q cannot run rclone, which indirect transfer (--cloud-storage) requires (reason %q): %s; use an rsync-transfer image that includes the rclone binary",
+			resolved, terminated.Reason, strings.TrimSpace(terminated.Message))
+	}
+	return nil
+}
+
 func getSourcePodSecurityContext(c client.Client, namespace string, pvcName string, image string) (*corev1.PodSecurityContext, error) {
 	return getIDsForNamespace(c, namespace, pvcName, image)
 }

--- a/cmd/transfer-pvc/transfer-pvc.go
+++ b/cmd/transfer-pvc/transfer-pvc.go
@@ -1063,16 +1063,10 @@ func inspectPVCFileOwnership(c client.Client, namespace string, pvcName string, 
 // ships a runnable rclone binary before crane commits any side effects.
 func verifyRcloneInImage(c client.Client, namespace string, image string, secCtx corev1.PodSecurityContext) error {
 	resolved := rsyncTransferImage(image)
-	podName := fmt.Sprintf("crane-rclone-check-%x", sha256.Sum256([]byte(resolved)))
-	if len(podName) > 63 {
-		podName = podName[:63]
-	}
-
-	nsName := types.NamespacedName{Name: podName, Namespace: namespace}
 	checkPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName,
-			Namespace: namespace,
+			GenerateName: "crane-rclone-check-",
+			Namespace:    namespace,
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:   corev1.RestartPolicyNever,
@@ -1087,18 +1081,15 @@ func verifyRcloneInImage(c client.Client, namespace string, image string, secCtx
 		},
 	}
 
-	// Best-effort removal of any stale check pod from a previous run so Create
-	// succeeds (the pod name is deterministic per image).
-	_ = c.Delete(context.TODO(), checkPod)
-	_ = wait.PollUntilContextTimeout(context.TODO(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
-		return errors.IsNotFound(c.Get(ctx, nsName, &corev1.Pod{})), nil
-	})
-
 	if err := c.Create(context.TODO(), checkPod); err != nil {
 		return fmt.Errorf("creating rclone-check pod: %w", err)
 	}
+	podName := checkPod.Name
+	nsName := types.NamespacedName{Name: podName, Namespace: namespace}
 	defer func() {
-		_ = c.Delete(context.TODO(), checkPod)
+		if err := c.Delete(context.TODO(), checkPod); err != nil && !errors.IsNotFound(err) {
+			log.Printf("failed to delete rclone-check pod %s/%s: %v", namespace, podName, err)
+		}
 	}()
 
 	// Allow generous time for a cold image pull; once pulled, "rclone version"

--- a/cmd/transfer-pvc/transfer-pvc_test.go
+++ b/cmd/transfer-pvc/transfer-pvc_test.go
@@ -902,6 +902,107 @@ func TestGetIDsForNamespace_InspectUsesTransferImage(t *testing.T) {
 	}
 }
 
+func TestVerifyRcloneInImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		image      string
+		terminated *corev1.ContainerStateTerminated
+		phase      corev1.PodPhase
+		wantErr    bool
+		wantErrHas string
+		wantImage  string
+	}{
+		{
+			name:       "rclone present: probe exits 0",
+			image:      "example.invalid/rsync-custom:has-rclone",
+			phase:      corev1.PodSucceeded,
+			terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+			wantErr:    false,
+			wantImage:  "example.invalid/rsync-custom:has-rclone",
+		},
+		{
+			name:  "rclone absent: container cannot start",
+			image: "example.invalid/rsync-custom:no-rclone",
+			phase: corev1.PodFailed,
+			terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 128,
+				Reason:   "StartError",
+				Message:  `exec: "rclone": executable file not found in $PATH`,
+			},
+			wantErr:    true,
+			wantErrHas: "executable file not found",
+			wantImage:  "example.invalid/rsync-custom:no-rclone",
+		},
+		{
+			name:       "empty image falls back to library default",
+			image:      "",
+			phase:      corev1.PodSucceeded,
+			terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+			wantErr:    false,
+			wantImage:  transport.DefaultRsyncTransferImage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := newTestScheme()
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "probe-ns"}}
+
+			var gotImage string
+			var gotCommand []string
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithRuntimeObjects(ns).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						if pod, ok := obj.(*corev1.Pod); ok && len(pod.Spec.Containers) > 0 {
+							gotImage = pod.Spec.Containers[0].Image
+							gotCommand = pod.Spec.Containers[0].Command
+						}
+						return cli.Create(ctx, obj, opts...)
+					},
+					Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := cli.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						pod, ok := obj.(*corev1.Pod)
+						if !ok {
+							return nil
+						}
+						pod.Status.Phase = tt.phase
+						pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+							State: corev1.ContainerState{Terminated: tt.terminated},
+						}}
+						return nil
+					},
+				}).
+				Build()
+
+			err := verifyRcloneInImage(c, "probe-ns", tt.image, corev1.PodSecurityContext{})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), tt.wantErrHas) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantErrHas)
+				}
+				if !strings.Contains(err.Error(), tt.wantImage) {
+					t.Errorf("error %q should name the image %q", err.Error(), tt.wantImage)
+				}
+			}
+			if gotImage != tt.wantImage {
+				t.Errorf("probe pod image = %q, want %q", gotImage, tt.wantImage)
+			}
+			if len(gotCommand) != 2 || gotCommand[0] != "rclone" || gotCommand[1] != "--version" {
+				t.Errorf("probe pod command = %v, want [rclone --version]", gotCommand)
+			}
+		})
+	}
+}
+
 func TestGetSecurityContextFromWorkload_NoWorkloads(t *testing.T) {
 	scheme := newTestScheme()
 


### PR DESCRIPTION
Fixes [964](https://github.com/migtools/crane/issues/964)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Indirect cloud-storage transfers now validate that the selected transfer image includes a working `rclone` installation before creating the destination volume.
- Transfers fail earlier with clearer errors when the image cannot run `rclone`, helping identify invalid images or image-pull problems before work begins.
- Improved handling of transfer pod security settings during pre-transfer validation.
- Repeated or concurrent validation checks now use unique temporary probes, reducing conflicts between transfer attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->